### PR TITLE
[Feat] 캘린더 생성 Api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.14.2'
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
@@ -8,11 +8,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.scheduo.domain.calendar.dto.CalendarRequestDto;
+import com.example.scheduo.domain.calendar.dto.CalendarResponseDto;
+import com.example.scheduo.domain.calendar.entity.Calendar;
 import com.example.scheduo.domain.calendar.service.CalendarService;
 import com.example.scheduo.global.response.ApiResponse;
+import com.example.scheduo.global.response.status.ResponseStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -20,7 +24,21 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/calendars")
 @Tag(name = "Calendar", description = "캘린더 관련 API")
 public class CalendarController {
+
 	private final CalendarService calendarService;
+
+	@PostMapping
+	public ApiResponse<CalendarResponseDto.CalendarInfo> createCalendar(
+		@Valid @RequestBody CalendarRequestDto.Create request
+	) {
+		//로그인 반영 후 memberId 수정 예정
+		Long memberId = 1L;
+
+		Calendar calendar = calendarService.createCalendar(request, memberId);
+
+		return ApiResponse.onSuccess(ResponseStatus.CREATED_CALENDAR,
+			CalendarResponseDto.CalendarInfo.fromEntity(calendar));
+	}
 
 	@PostMapping("/{calendarId}/invite")
 	@Operation(summary = "캘린더 초대", description = "캘린더에 사용자를 초대합니다.")

--- a/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
@@ -1,5 +1,6 @@
 package com.example.scheduo.domain.calendar.controller;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,7 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.scheduo.domain.calendar.dto.CalendarRequestDto;
 import com.example.scheduo.domain.calendar.dto.CalendarResponseDto;
-import com.example.scheduo.domain.calendar.entity.Calendar;
 import com.example.scheduo.domain.calendar.service.CalendarService;
 import com.example.scheduo.global.response.ApiResponse;
 import com.example.scheduo.global.response.status.ResponseStatus;
@@ -27,17 +27,14 @@ public class CalendarController {
 
 	private final CalendarService calendarService;
 
-	@PostMapping
+	@PostMapping()
 	public ApiResponse<CalendarResponseDto.CalendarInfo> createCalendar(
+		Authentication authentication,
 		@Valid @RequestBody CalendarRequestDto.Create request
 	) {
-		//로그인 반영 후 memberId 수정 예정
-		Long memberId = 1L;
-
-		Calendar calendar = calendarService.createCalendar(request, memberId);
-
-		return ApiResponse.onSuccess(ResponseStatus.CREATED_CALENDAR,
-			CalendarResponseDto.CalendarInfo.fromEntity(calendar));
+		Long memberId = (Long)authentication.getPrincipal();
+		CalendarResponseDto.CalendarInfo calendarInfo = calendarService.createCalendar(request, memberId);
+		return ApiResponse.onSuccess(ResponseStatus.CREATED, calendarInfo);
 	}
 
 	@PostMapping("/{calendarId}/invite")

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarRequestDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarRequestDto.java
@@ -1,5 +1,12 @@
 package com.example.scheduo.domain.calendar.dto;
 
+import java.util.List;
+
+import com.example.scheduo.domain.calendar.entity.Role;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +18,25 @@ public class CalendarRequestDto {
 	@NoArgsConstructor
 	public static class Invite {
 		private Long memberId;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Create {
+		@NotBlank(message = "캘린더 제목은 필수입니다.")
+		private String title;
+
+		@Valid
+		private List<Participant> participants;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Participant {
+		@NotNull(message = "memberId는 필수입니다.")
+		private Long memberId;
+		private Role role;
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.scheduo.domain.calendar.dto;
+
+import com.example.scheduo.domain.calendar.entity.Calendar;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CalendarResponseDto {
+
+	@Builder
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class CalendarInfo {
+		private Long calendarId;
+		private String calendarTitle;
+
+		public static CalendarInfo fromEntity(Calendar calendar) {
+			return new CalendarInfo(calendar.getId(), calendar.getName());
+		}
+	}
+}

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
@@ -17,7 +17,7 @@ public class CalendarResponseDto {
 		private Long calendarId;
 		private String calendarTitle;
 
-		public static CalendarInfo fromEntity(Calendar calendar) {
+		public static CalendarInfo from(Calendar calendar) {
 			return new CalendarInfo(calendar.getId(), calendar.getName());
 		}
 	}

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
@@ -39,8 +39,6 @@ public class Calendar extends BaseEntity {
 
 	private String name;
 
-	private boolean isShared;
-
 	@OneToMany(mappedBy = "calendar", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Participant> participants = new ArrayList<>();
 

--- a/src/main/java/com/example/scheduo/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/repository/CalendarRepository.java
@@ -2,10 +2,9 @@ package com.example.scheduo.domain.calendar.repository;
 
 import java.util.Optional;
 
+import com.example.scheduo.domain.calendar.entity.Calendar;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import com.example.scheduo.domain.calendar.entity.Calendar;
 
 public interface CalendarRepository extends JpaRepository<Calendar, Long> {
 	@Query("SELECT c FROM Calendar c LEFT JOIN FETCH c.participants WHERE c.id = :calendarId")

--- a/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
@@ -1,9 +1,14 @@
 package com.example.scheduo.domain.calendar.service;
 
+import com.example.scheduo.domain.calendar.dto.CalendarRequestDto;
+import com.example.scheduo.domain.calendar.dto.CalendarResponseDto;
+
 public interface CalendarService {
 	void inviteMember(Long calendarId, Long inviterId, Long inviteeId);
 
 	void acceptInvitation(Long calendarId, Long memberId);
 
 	void rejectInvitation(Long calendarId, Long memberId);
+
+	CalendarResponseDto.CalendarInfo createCalendar(CalendarRequestDto.Create calendarInfo, Long memberId);
 }

--- a/src/main/java/com/example/scheduo/global/response/ApiResponse.java
+++ b/src/main/java/com/example/scheduo/global/response/ApiResponse.java
@@ -29,6 +29,10 @@ public class ApiResponse<T> {
 		return new ApiResponse<>(ResponseStatus.OK.getHttpStatus().value(), true, message, result);
 	}
 
+	public static <T> ApiResponse<T> onSuccess(ResponseStatus status, T result) {
+		return new ApiResponse<>(status.getHttpStatus().value(), true, status.getMessage(), result);
+	}
+
 	// 실패 응답 생성
 	public static ErrorResponseDto onFailure(ResponseStatus status) {
 		return ErrorResponseDto.of(status.getHttpStatus().value(), status.getStatus(), status.getMessage());

--- a/src/main/java/com/example/scheduo/global/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/scheduo/global/response/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.scheduo.global.response.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -37,5 +38,17 @@ public class GlobalExceptionHandler {
 		log.error("[UnhandledError] {} - {}", response.getStatus(), ex.getMessage());
 
 		return ResponseEntity.status(ResponseStatus.INTERNAL_SERVER_ERROR.getHttpStatus()).body(response);
+	}
+
+	// Validation 에러
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponseDto> handleValidationException(MethodArgumentNotValidException ex) {
+		String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+		ResponseStatus status = ResponseStatus.VALIDATION_ERROR;
+
+		ErrorResponseDto response = ApiResponse.onFailure(status.getHttpStatus().value(), status.getStatus(), message);
+		log.error("[ValidationError] {} - {}", response.getStatus(), message);
+
+		return ResponseEntity.status(ResponseStatus.VALIDATION_ERROR.getHttpStatus()).body(response);
 	}
 }

--- a/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
+++ b/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
@@ -10,12 +10,14 @@ import lombok.RequiredArgsConstructor;
 public enum ResponseStatus {
 	//일반적인 응답
 	OK(HttpStatus.OK, "SUCCESS", "OK."),
+	CREATED(HttpStatus.CREATED, "CREATED", "OK."),
 
 	// 에러 응답
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_0001", "서버 에러가 발생했습니다."),
 	NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_0002", "리소스를 찾을 수 없습니다."),
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_0003", "인증에 실패했습니다."),
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_0004", "권한이 없습니다."),
+	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_0005", "잘못된 형식 입니다."),
 
 	// 토큰 관련 에러 응답
 	NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN_0001", "토큰이 없습니다."),

--- a/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
+++ b/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
@@ -17,13 +17,12 @@ public enum ResponseStatus {
 	NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_0002", "리소스를 찾을 수 없습니다."),
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_0003", "인증에 실패했습니다."),
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_0004", "권한이 없습니다."),
-	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_0005", "잘못된 형식 입니다."),
+	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_0005", "입력하신 값의 형식이 올바르지 않습니다. 올바른 형식으로 입력해주세요."),
 
 	// 토큰 관련 에러 응답
 	NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN_0001", "토큰이 없습니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN_0002", "토큰이 유효하지 않습니다."),
 	DEFAULT_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "TOKEN_0003", "인증에 실패하였습니다."),
-
 
 	// 멤버 관련 에러 응답
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_0001", "멤버를 찾을 수 없습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #7 

## 🎁 작업 내용
### 1. 캘린더 생성 Api 구현
- 캘린더 레코드 Calendar table에 생성
- 참여자들 Participant table에 생성 (owner은 생성X, Calendar에 이미 memberId로 들어가 있기 때문에)
- 참여자들 디폴트 status PENDDING 설정
- 제목, memberId null값일 경우 validation Error 나도록 설정 (enum값도 체크하고 싶었는데 커스텀 데코레이터 만들어야 하는것 같아서 너무 어려워서 일단 포기했습니다..)
### 2. gradle 변경
- request dto validation 체크를 위해 gradle 변경했습니다.
### 3. 성공, 에러 응답 변경
- 성공 응답이 200밖에 없길래 201과 같은 응답 status가 들어갈 수 있도록 onSuccess 하나 더 추가해주었습니다.
- validation 데코레이터 사용 시 현재 exception handler로는 잡히지 않아서 request body validation용 exception handler를 추가했습니다. (맞게 한건지 모르겠습니다)

**성공**
<img width="1055" alt="스크린샷 2025-05-20 오후 6 17 53" src="https://github.com/user-attachments/assets/3560655a-a160-4f3c-acb0-d3e6d2a4868f" />

**제목 누락**
<img width="1058" alt="스크린샷 2025-05-20 오후 6 20 02" src="https://github.com/user-attachments/assets/82803331-abe4-43ef-bbfb-0cc9c6393320" />

**memberId 누락**
<img width="1056" alt="스크린샷 2025-05-20 오후 6 22 17" src="https://github.com/user-attachments/assets/a494a6db-fa3b-41f3-81b3-78a76b02e284" />

## P.S
- 스린이 입니다.. 나름 코드 잘 짜보려고 노력했는데 부족한게 많을수도 있고 제가 임의로 추가한것들 (성공, 에러 응답 같은거)이 잘못 됐을수도 있으니 이것 저것 많이 지적해주시면 감사하겠습니다... 

