### PR TITLE
[Fix] 캘린더 생성 Api 수정

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.example.scheduo.domain.common.BaseEntity;
-import com.example.scheduo.domain.member.entity.Member;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -12,8 +11,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -32,10 +29,6 @@ public class Calendar extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "memberId")
-	private Member member;
 
 	private String name;
 

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Role.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Role.java
@@ -1,5 +1,5 @@
 package com.example.scheduo.domain.calendar.entity;
 
 public enum Role {
-	EDIT, VIEW
+	EDIT, VIEW, OWNER
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -39,6 +39,7 @@ public class CalendarServiceImpl implements CalendarService {
 		Calendar calendar = calendarRepository.findByIdWithParticipants(calendarId)
 			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
 
+		//Todo 멤버 삭제에 따른 수정 필요
 		if (!calendar.getMember().getId().equals(inviterId)) {
 			throw new ApiException(ResponseStatus.MEMBER_NOT_OWNER);
 		}
@@ -102,13 +103,21 @@ public class CalendarServiceImpl implements CalendarService {
 
 		Calendar calendar = Calendar.builder()
 			.name(request.getTitle())
-			.member(owner)
 			.participants(new ArrayList<>())
 			.build();
 
+		Participant ownerParticipant = Participant.builder()
+			.member(owner)
+			.nickname(owner.getNickname())
+			.role(Role.OWNER)
+			.status(ParticipationStatus.ACCEPTED)
+			.build();
+
+		calendar.addParticipant(ownerParticipant);
+
 		List<CalendarRequestDto.Participant> requestParticipants = request.getParticipants();
 
-		if (requestParticipants != null) {
+		if (requestParticipants != null && !requestParticipants.isEmpty()) {
 			List<Long> participantIds = requestParticipants.stream()
 				.map(CalendarRequestDto.Participant::getMemberId)
 				.toList();

--- a/src/main/java/com/example/scheduo/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/member/service/impl/MemberServiceImpl.java
@@ -69,6 +69,7 @@ public class MemberServiceImpl implements MemberService {
 			.build();
 		memberRepository.save(member);
 
+		//Todo 멤버 삭제에 따른 수정 필요
 		Calendar defaultCalendar = Calendar.builder()
 			.member(member)
 			.name("기본 캘린더")

--- a/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
@@ -310,8 +310,9 @@ class CalendarControllerTest(
     describe("POST /calendars") {
         context("정상 캘린더 생성 요청일 경우") {
             it("생성된 캘린더 정보와 함께 200 OK를 반환한다") {
-                val owner = memberRepository.save(createMember())
+                val owner = createMember()
                 val members = listOf(
+                    owner,
                     createMember(email = "test2@gmail.com"),
                     createMember(email = "test3@gmail.com"),
                 )
@@ -340,8 +341,9 @@ class CalendarControllerTest(
 
         context("제목이 빈 스트링이거나 null 일경우") {
             it("400 Valid Error를 반환한다") {
-                val owner = memberRepository.save(createMember())
+                val owner = createMember()
                 val members = listOf(
+                    owner,
                     createMember(email = "test2@gmail.com"),
                     createMember(email = "test3@gmail.com"),
                 )

--- a/src/test/kotlin/com/example/scheduo/fixture/CalendarFixture.kt
+++ b/src/test/kotlin/com/example/scheduo/fixture/CalendarFixture.kt
@@ -2,18 +2,15 @@ package com.example.scheduo.fixture
 
 import com.example.scheduo.domain.calendar.entity.Calendar
 import com.example.scheduo.domain.calendar.entity.Participant
-import com.example.scheduo.domain.member.entity.Member
 
 
 fun createCalendar(
     id: Long? = null,
     name: String = "캘린더 이름",
-    member: Member = createMember(),
     participants: List<Participant> = emptyList()
 ): Calendar {
     return Calendar(
         id,
-        member,
         name,
         participants
     )


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #36

## 🎁 작업 내용
- Role에 OWNER추가
- Calendar member 삭제
- 캘린더 생성시 owner도 participants로 추가

## 건의사항
- 회원가입할때도 캘린더 생성하고, owner를 participants로 추가하는 로직이 똑같이 실행되는데 이거 공통으로 분리해서 해도 좋으려나요? 약간 Factory 개념으로요.. 근데 메서드 분리를 어디다 해야할지 몰라서 일단 뒀습니다.