### PR TITLE
[Feat] 모든 캘린더 조회 Api 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
@@ -2,6 +2,7 @@ package com.example.scheduo.domain.calendar.controller;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -81,5 +82,12 @@ public class CalendarController {
 		Long memberId = (Long)authentication.getPrincipal();
 		calendarService.deleteCalendar(calendarId, memberId);
 		return ApiResponse.onSuccess();
+	}
+
+	@GetMapping()
+	public ApiResponse<CalendarResponseDto.CalendarInfoList> get(Authentication authentication) {
+		Long memberId = (Long)authentication.getPrincipal();
+		CalendarResponseDto.CalendarInfoList calendars = calendarService.getCalendars(memberId);
+		return ApiResponse.onSuccess(calendars);
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
@@ -1,5 +1,8 @@
 package com.example.scheduo.domain.calendar.dto;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.example.scheduo.domain.calendar.entity.Calendar;
 
 import lombok.AllArgsConstructor;
@@ -15,10 +18,30 @@ public class CalendarResponseDto {
 	@AllArgsConstructor
 	public static class CalendarInfo {
 		private Long calendarId;
-		private String calendarTitle;
+		private String title;
 
 		public static CalendarInfo from(Calendar calendar) {
-			return new CalendarInfo(calendar.getId(), calendar.getName());
+			return CalendarInfo.builder()
+				.calendarId(calendar.getId())
+				.title(calendar.getName())
+				.build();
+		}
+	}
+
+	@Builder
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class CalendarInfoList {
+		private List<CalendarInfo> calendars;
+
+		public static CalendarInfoList from(List<Calendar> calendars) {
+			List<CalendarInfo> calendarInfoList = calendars.stream()
+				.map(CalendarInfo::from)
+				.collect(Collectors.toList());
+			return CalendarInfoList.builder()
+				.calendars(calendarInfoList)
+				.build();
 		}
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/repository/ParticipantJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/repository/ParticipantJpqlRepository.java
@@ -1,9 +1,13 @@
 package com.example.scheduo.domain.calendar.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import com.example.scheduo.domain.calendar.entity.Calendar;
 import com.example.scheduo.domain.calendar.entity.Participant;
 
 public interface ParticipantJpqlRepository {
 	Optional<Participant> findOwnerByCalendarId(Long calendarId);
+
+	List<Calendar> findCalendarsByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/repository/impl/ParticipantJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/repository/impl/ParticipantJpqlRepositoryImpl.java
@@ -1,10 +1,13 @@
 package com.example.scheduo.domain.calendar.repository.impl;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.example.scheduo.domain.calendar.entity.Calendar;
 import com.example.scheduo.domain.calendar.entity.Participant;
+import com.example.scheduo.domain.calendar.entity.ParticipationStatus;
 import com.example.scheduo.domain.calendar.entity.Role;
 import com.example.scheduo.domain.calendar.repository.ParticipantJpqlRepository;
 
@@ -28,5 +31,17 @@ public class ParticipantJpqlRepositoryImpl implements ParticipantJpqlRepository 
 			.setParameter("role", Role.OWNER)
 			.getResultStream()
 			.findFirst();
+	}
+
+	@Override
+	public List<Calendar> findCalendarsByMemberId(Long memberId) {
+		String jpql = """
+				SELECT p.calendar FROM Participant p
+				WHERE p.member.id = :memberId AND p.status = :status
+			""";
+		return entityManager.createQuery(jpql, Calendar.class)
+			.setParameter("memberId", memberId)
+			.setParameter("status", ParticipationStatus.ACCEPTED)
+			.getResultList();
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
@@ -15,4 +15,6 @@ public interface CalendarService {
 	void editCalendar(CalendarRequestDto.Edit editInfo, Long calendarId, Long memberId);
 
 	void deleteCalendar(Long calendarId, Long memberId);
+
+	CalendarResponseDto.CalendarInfoList getCalendars(Long memberId);
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -207,11 +207,19 @@ public class CalendarServiceImpl implements CalendarService {
 	public void deleteCalendar(Long calendarId, Long memberId) {
 		Participant owner = participantRepository.findOwnerByCalendarId(calendarId)
 			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
-		
+
 		if (!owner.getMember().getId().equals(memberId)) {
 			throw new ApiException(ResponseStatus.MEMBER_NOT_OWNER);
 		}
 
 		calendarRepository.deleteById(calendarId);
+	}
+
+	@Override
+	@Transactional
+	public CalendarResponseDto.CalendarInfoList getCalendars(Long memberId) {
+		List<Calendar> calendars = participantRepository.findCalendarsByMemberId(memberId);
+
+		return CalendarResponseDto.CalendarInfoList.from(calendars);
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #42 

## 🎁 작업 내용
- 모든 캘린더 조회 Api 구현
    - jpql 사용하여 조회 쿼리 작성 (jpa 사용할 경우 내부에서 participant 조회 쿼리를 날린 후 calendar 조회하는 쿼리를 또 날린다고 알고있어서 한번의 쿼리로 조회할 수 있게 jpql 사용했습니다) 
- 테스트 코드 작성
    - 정상적으로 조회 요청이 될 경우 (참여한 캘린더들이 있고, 참여상태가 ACCEPT)
    - 초대는 받았지만, 참여상태가 ACCEPT가 아닐 경우
    - 아무런 캘린더에도 참여하거나 초대받지 않았을 경우
    - 세 경우 모두 200 OK 반환하지만 data 값이 달라집니다.