### PR TITLE
[Feat] 캘린더 삭제 Api 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
@@ -1,6 +1,7 @@
 package com.example.scheduo.domain.calendar.controller;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -71,6 +72,14 @@ public class CalendarController {
 		Authentication authentication) {
 		Long memberId = (Long)authentication.getPrincipal();
 		calendarService.editCalendar(editInfo, calendarId, memberId);
+		return ApiResponse.onSuccess();
+	}
+
+	@DeleteMapping("/{calendarId}")
+	public ApiResponse<?> delete(@PathVariable("calendarId") Long calendarId,
+		Authentication authentication) {
+		Long memberId = (Long)authentication.getPrincipal();
+		calendarService.deleteCalendar(calendarId, memberId);
 		return ApiResponse.onSuccess();
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
@@ -13,4 +13,6 @@ public interface CalendarService {
 	CalendarResponseDto.CalendarInfo createCalendar(CalendarRequestDto.Create calendarInfo, Long memberId);
 
 	void editCalendar(CalendarRequestDto.Edit editInfo, Long calendarId, Long memberId);
+
+	void deleteCalendar(Long calendarId, Long memberId);
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -201,4 +201,17 @@ public class CalendarServiceImpl implements CalendarService {
 			participant.updateNickname(editInfo.getNickname());
 		}
 	}
+
+	@Override
+	@Transactional
+	public void deleteCalendar(Long calendarId, Long memberId) {
+		Participant owner = participantRepository.findOwnerByCalendarId(calendarId)
+			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
+		
+		if (!owner.getMember().getId().equals(memberId)) {
+			throw new ApiException(ResponseStatus.MEMBER_NOT_OWNER);
+		}
+
+		calendarRepository.deleteById(calendarId);
+	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #44 

## 🎁 작업 내용
- 캘린더 삭제 Api 구현
- 캘린더 삭제 테스트 코드 작성
    - 정상 캘린더 삭제 요청일 경우
    - 캘린더가 존재하지 않을 경우
    - 캘린더 소유자가 아닌 사람이 캘린더 삭제를 요청할 경우

## 질문사항
- participantRepository에 findOwnerByCalendarId가 있어서 썼는데, 아무데도 사용이 안되었더라고요? 추측키로는 사용자 초대에서 사용하시려고 만드신 것 같은데 해당 쿼리를 만들고 그냥 다른방식으로 owner를 찾으신 이유가 궁금합니다.