### PR TITLE
[Feat] 캘린더 개별 조회 api 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
@@ -112,6 +112,7 @@ public class CalendarController {
 	}
 
 	@GetMapping("/{calendarId}")
+	@Operation(summary = "캘린더 개별 조회", description = "특정 캘린더의 정보를 조회합니다.")
 	public ApiResponse<CalendarResponseDto.CalendarDetailInfo> get(@PathVariable("calendarId") Long calendarId,
 		@RequestMember Member member) {
 		CalendarResponseDto.CalendarDetailInfo calendar = calendarService.getCalendar(calendarId, member);

--- a/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
@@ -110,4 +110,11 @@ public class CalendarController {
 		calendarService.removeParticipant(calendarId, participantId, member.getId());
 		return ApiResponse.onSuccess();
 	}
+
+	@GetMapping("/{calendarId}")
+	public ApiResponse<CalendarResponseDto.CalendarDetailInfo> get(@PathVariable("calendarId") Long calendarId,
+		@RequestMember Member member) {
+		CalendarResponseDto.CalendarDetailInfo calendar = calendarService.getCalendar(calendarId, member);
+		return ApiResponse.onSuccess(calendar);
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
@@ -79,7 +79,7 @@ public class CalendarResponseDto {
 	@Getter
 	@NoArgsConstructor
 	@AllArgsConstructor
-	private static class ParticipantInfo {
+	public static class ParticipantInfo {
 		private Long participantId;
 		private String nickname;
 		private Role role;

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.example.scheduo.domain.calendar.entity.Calendar;
+import com.example.scheduo.domain.calendar.entity.Participant;
+import com.example.scheduo.domain.calendar.entity.ParticipationStatus;
+import com.example.scheduo.domain.calendar.entity.Role;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,6 +44,53 @@ public class CalendarResponseDto {
 				.collect(Collectors.toList());
 			return CalendarInfoList.builder()
 				.calendars(calendarInfoList)
+				.build();
+		}
+	}
+
+	@Builder
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class CalendarDetailInfo {
+		private Long calendarId;
+		private String title;
+		private Role memberRole;
+		private String memberNickname;
+		private List<ParticipantInfo> participants;
+
+		public static CalendarDetailInfo from(Calendar calendar, Participant myParticipant) {
+			List<ParticipantInfo> participantInfoList = calendar.getParticipants().stream()
+				.filter(p -> p.getStatus().equals(ParticipationStatus.ACCEPTED))
+				.map(ParticipantInfo::from)
+				.collect(Collectors.toList());
+
+			return CalendarDetailInfo.builder()
+				.calendarId(calendar.getId())
+				.title(calendar.getName())
+				.memberRole(myParticipant.getRole())
+				.memberNickname(myParticipant.getNickname())
+				.participants(participantInfoList)
+				.build();
+		}
+	}
+
+	@Builder
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class ParticipantInfo {
+		private Long participantId;
+		private String nickname;
+		private Role role;
+		private String email;
+
+		public static ParticipantInfo from(Participant participant) {
+			return ParticipantInfo.builder()
+				.participantId(participant.getId())
+				.nickname(participant.getNickname())
+				.role(participant.getRole())
+				.email(participant.getMember().getEmail())
 				.build();
 		}
 	}

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarResponseDto.java
@@ -7,6 +7,7 @@ import com.example.scheduo.domain.calendar.entity.Calendar;
 import com.example.scheduo.domain.calendar.entity.Participant;
 import com.example.scheduo.domain.calendar.entity.ParticipationStatus;
 import com.example.scheduo.domain.calendar.entity.Role;
+import com.example.scheduo.domain.member.entity.Member;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -59,10 +60,10 @@ public class CalendarResponseDto {
 		private String memberNickname;
 		private List<ParticipantInfo> participants;
 
-		public static CalendarDetailInfo from(Calendar calendar, Participant myParticipant) {
+		public static CalendarDetailInfo from(Calendar calendar, Participant myParticipant, Member member) {
 			List<ParticipantInfo> participantInfoList = calendar.getParticipants().stream()
 				.filter(p -> p.getStatus().equals(ParticipationStatus.ACCEPTED))
-				.map(ParticipantInfo::from)
+				.map(p -> ParticipantInfo.from(p, member))
 				.collect(Collectors.toList());
 
 			return CalendarDetailInfo.builder()
@@ -84,13 +85,17 @@ public class CalendarResponseDto {
 		private String nickname;
 		private Role role;
 		private String email;
+		private boolean me;
 
-		public static ParticipantInfo from(Participant participant) {
+		public static ParticipantInfo from(Participant participant, Member member) {
+			boolean me = participant.getMember().getId().equals(member.getId());
+
 			return ParticipantInfo.builder()
 				.participantId(participant.getId())
 				.nickname(participant.getNickname())
 				.role(participant.getRole())
 				.email(participant.getMember().getEmail())
+				.me(me)
 				.build();
 		}
 	}

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
@@ -109,6 +109,10 @@ public class Participant extends BaseEntity {
 
 	public boolean isAccepted() {
 		return this.status == ParticipationStatus.ACCEPTED;
+	public void validateAccessible() {
+		if (this.status == ParticipationStatus.ACCEPTED) {
+			throw new ApiException(ResponseStatus.MEMBER_NOT_ACCEPT);
+		}
 	}
 
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
@@ -107,10 +107,8 @@ public class Participant extends BaseEntity {
 		}
 	}
 
-	public boolean isAccepted() {
-		return this.status == ParticipationStatus.ACCEPTED;
-	public void validateAccessible() {
-		if (this.status == ParticipationStatus.ACCEPTED) {
+	public void validateAccpetedParticipant() {
+		if (this.status != ParticipationStatus.ACCEPTED) {
 			throw new ApiException(ResponseStatus.MEMBER_NOT_ACCEPT);
 		}
 	}

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
@@ -106,4 +106,9 @@ public class Participant extends BaseEntity {
 			throw new ApiException(ResponseStatus.CANNOT_REMOVE_OWNER);
 		}
 	}
+
+	public boolean isAccepted() {
+		return this.status == ParticipationStatus.ACCEPTED;
+	}
+
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/repository/CalendarJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/repository/CalendarJpqlRepository.java
@@ -7,4 +7,5 @@ import com.example.scheduo.domain.calendar.entity.Calendar;
 public interface CalendarJpqlRepository {
 	Optional<Calendar> findByIdWithParticipants(Long calendarId);
 
+	Optional<Calendar> findByIdWithParticipantsAndMembers(Long calendarId);
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/repository/impl/CalendarJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/repository/impl/CalendarJpqlRepositoryImpl.java
@@ -27,4 +27,18 @@ public class CalendarJpqlRepositoryImpl implements CalendarJpqlRepository {
 			.getResultStream()
 			.findFirst();
 	}
+
+	@Override
+	public Optional<Calendar> findByIdWithParticipantsAndMembers(Long calendarId) {
+		String jpql = """
+				SELECT c FROM Calendar c
+				JOIN FETCH c.participants p
+				JOIN FETCH p.member
+				WHERE c.id = :calendarId
+			""";
+		return entityManager.createQuery(jpql, Calendar.class)
+			.setParameter("calendarId", calendarId)
+			.getResultStream()
+			.findFirst();
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
@@ -22,4 +22,6 @@ public interface CalendarService {
 	void updateParticipantRole(Long calendarId, Long participantId, CalendarRequestDto.UpdateParticipantRole request, Long requesterId);
 
 	void removeParticipant(Long calendarId, Long participantId, Long requesterId);
+
+	CalendarResponseDto.CalendarDetailInfo getCalendar(Long calendarId, Member member);
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -210,9 +210,7 @@ public class CalendarServiceImpl implements CalendarService {
 		Participant myParticipant = calendar.findParticipant(member.getId())
 			.orElseThrow(() -> new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION));
 
-		if (!myParticipant.isAccepted()) {
-			throw new ApiException(ResponseStatus.MEMBER_NOT_ACCEPT);
-		}
+		myParticipant.validateAccessible();
 
 		return CalendarResponseDto.CalendarDetailInfo.from(calendar, myParticipant);
 	}

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -204,7 +204,7 @@ public class CalendarServiceImpl implements CalendarService {
 	@Override
 	@Transactional
 	public CalendarResponseDto.CalendarDetailInfo getCalendar(Long calendarId, Member member) {
-		Calendar calendar = calendarRepository.findById(calendarId)
+		Calendar calendar = calendarRepository.findByIdWithParticipantsAndMembers(calendarId)
 			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
 
 		Participant myParticipant = calendar.findParticipant(member.getId())

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -203,6 +203,22 @@ public class CalendarServiceImpl implements CalendarService {
 
 	@Override
 	@Transactional
+	public CalendarResponseDto.CalendarDetailInfo getCalendar(Long calendarId, Member member) {
+		Calendar calendar = calendarRepository.findById(calendarId)
+			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
+
+		Participant myParticipant = calendar.findParticipant(member.getId())
+			.orElseThrow(() -> new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION));
+
+		if (!myParticipant.isAccepted()) {
+			throw new ApiException(ResponseStatus.MEMBER_NOT_ACCEPT);
+		}
+
+		return CalendarResponseDto.CalendarDetailInfo.from(calendar, myParticipant);
+	}
+
+	@Override
+	@Transactional
 	public void updateParticipantRole(Long calendarId, Long participantId, CalendarRequestDto.UpdateParticipantRole request, Long requesterId) {
 		Calendar calendar = calendarRepository.findByIdWithParticipants(calendarId)
 			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -210,14 +210,15 @@ public class CalendarServiceImpl implements CalendarService {
 		Participant myParticipant = calendar.findParticipant(member.getId())
 			.orElseThrow(() -> new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION));
 
-		myParticipant.validateAccessible();
+		myParticipant.validateAccpetedParticipant();
 
-		return CalendarResponseDto.CalendarDetailInfo.from(calendar, myParticipant);
+		return CalendarResponseDto.CalendarDetailInfo.from(calendar, myParticipant, member);
 	}
 
 	@Override
 	@Transactional
-	public void updateParticipantRole(Long calendarId, Long participantId, CalendarRequestDto.UpdateParticipantRole request, Long requesterId) {
+	public void updateParticipantRole(Long calendarId, Long participantId,
+		CalendarRequestDto.UpdateParticipantRole request, Long requesterId) {
 		Calendar calendar = calendarRepository.findByIdWithParticipants(calendarId)
 			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
 

--- a/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
@@ -711,7 +711,7 @@ class CalendarControllerTest(
                 val json = objectMapper.readTree(response.contentAsString)
                 json["data"]["calendars"].size() shouldBeGreaterThan 0
 
-                json["data"]["calendars"][0]["calendarId"].asLong() shouldBeGreaterThan 0
+                json["data"]["calendars"][0]["calendarId"].asLong() shouldBe calendar.id
                 json["data"]["calendars"][0]["title"].asText() shouldBe calendar.name
             }
         }
@@ -1300,6 +1300,89 @@ class CalendarControllerTest(
                 val response = req.delete("/calendars/${calendar.id}/participants/${targetParticipant.id}", validToken)
 
                 res.assertFailure(response, ResponseStatus.INVALID_CALENDAR_PARTICIPATION)
+            }
+        }
+    }
+
+    describe("GET /calendars/{calendarId}") {
+        context("정상 단일 캘린더 조회 요청일 경우") {
+            it("200 OK를 반환하고 캘린더 상세 정보를 반환한다.") {
+                val member = memberRepository.save(createMember())
+                val calendar = calendarRepository.save(createCalendar())
+                val participant = participantRepository.save(
+                    createParticipant(
+                        calendar = calendar,
+                        member = member,
+                        participationStatus = ParticipationStatus.ACCEPTED,
+                        nickname = "testNickname"
+                    )
+                )
+
+                val token = jwtFixture.createValidToken(member.id)
+
+                val response = req.get("/calendars/${calendar.id}", token)
+
+                res.assertSuccess(response)
+
+                val json = objectMapper.readTree(response.contentAsString)
+                val data = json["data"]
+
+                data["calendarId"].asLong() shouldBe calendar.id
+                data["title"].asText() shouldBe calendar.name
+                data["memberRole"].asText() shouldBe participant.role.name
+                data["memberNickname"].asText() shouldBe participant.nickname
+                data["participants"].size() shouldBe 1
+
+                val resParticipant = data["participants"][0]
+                resParticipant["participantId"].asLong() shouldBe participant.id
+                resParticipant["email"].asText() shouldBe member.email
+                resParticipant["role"].asText() shouldBe participant.role.name
+                resParticipant["nickname"].asText() shouldBe participant.nickname
+            }
+        }
+
+        context("캘린더가 존재하지 않는 경우") {
+            it("404 Not Found를 반환한다") {
+                val member = memberRepository.save(createMember())
+                val token = jwtFixture.createValidToken(member.id)
+
+                val response = req.delete("/calendars/999", token)
+
+                res.assertFailure(response, ResponseStatus.CALENDAR_NOT_FOUND)
+            }
+        }
+
+        context("캘린더 참여 정보가 없을 경우") {
+            it("403 Forbidden을 반환한다") {
+                val member = memberRepository.save(createMember())
+                val calendar = calendarRepository.save(createCalendar())
+
+                val token = jwtFixture.createValidToken(member.id)
+
+                val response = req.get("/calendars/${calendar.id}", token)
+
+                res.assertFailure(response, ResponseStatus.INVALID_CALENDAR_PARTICIPATION)
+            }
+        }
+
+        context("캘린더 참여 수락을 하지 않았을 경우") {
+            it("403 Forbidden을 반환한다") {
+                val member = memberRepository.save(createMember())
+                val calendar = calendarRepository.save(createCalendar())
+                participantRepository.save(
+                    createParticipant(
+                        calendar = calendar,
+                        member = member,
+                        participationStatus = ParticipationStatus.PENDING,
+                        nickname = "testNickname"
+                    )
+                )
+
+                val token = jwtFixture.createValidToken(member.id)
+
+                val response = req.get("/calendars/${calendar.id}", token)
+
+                res.assertFailure(response, ResponseStatus.MEMBER_NOT_ACCEPT)
             }
         }
     }

--- a/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
@@ -1338,6 +1338,7 @@ class CalendarControllerTest(
                 resParticipant["email"].asText() shouldBe member.email
                 resParticipant["role"].asText() shouldBe participant.role.name
                 resParticipant["nickname"].asText() shouldBe participant.nickname
+                resParticipant["me"].asBoolean() shouldBe true
             }
         }
 
@@ -1355,7 +1356,15 @@ class CalendarControllerTest(
         context("캘린더 참여 정보가 없을 경우") {
             it("403 Forbidden을 반환한다") {
                 val member = memberRepository.save(createMember())
+                val member2 = memberRepository.save(createMember())
                 val calendar = calendarRepository.save(createCalendar())
+                participantRepository.save(
+                    createParticipant(
+                        calendar = calendar,
+                        member = member2,
+                        participationStatus = ParticipationStatus.ACCEPTED,
+                    )
+                )
 
                 val token = jwtFixture.createValidToken(member.id)
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #56 

## 🎁 작업 내용
- 캘린더 개별 조회 api 구현
- 테스트 코드 작성
    - 정상 요청일 경우
    - 캘린더가 존재하지 않을 경우
    - 캘린더에 참여 정보가 없을 경우
    - 캘린더에 참여 정보는 있으나 ACCEPT 상태가 아닐 경우

## 코멘트
- TDA를 생각하면서 짜긴 했는데 이게.. 이렇게 하는게 맞나요..?