### PR TITLE
월별 일정 조회(단일캘린더) api 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.example.scheduo.domain.common.BaseEntity;
+import com.example.scheduo.global.response.ApiResponse;
 import com.example.scheduo.global.response.exception.ApiException;
 import com.example.scheduo.global.response.status.ResponseStatus;
 
@@ -108,5 +109,11 @@ public class Calendar extends BaseEntity {
 		this.participants.remove(targetParticipant);
 
 		return targetParticipant; // 삭제를 위해 반환
+	}
+
+	public boolean validateParticipant(Long memberId) {
+		return this.findParticipant(memberId)
+			.orElseThrow(()-> new ApiException(ResponseStatus.PARTICIPANT_NOT_FOUND))
+			.isAccepted();
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
@@ -106,4 +106,8 @@ public class Participant extends BaseEntity {
 			throw new ApiException(ResponseStatus.CANNOT_REMOVE_OWNER);
 		}
 	}
+
+	public boolean isAccepted() {
+		return this.status == ParticipationStatus.ACCEPTED;
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -1,12 +1,15 @@
 package com.example.scheduo.domain.schedule.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.scheduo.domain.member.entity.Member;
 import com.example.scheduo.domain.schedule.dto.ScheduleRequestDto;
+import com.example.scheduo.domain.schedule.dto.ScheduleResponseDto;
 import com.example.scheduo.domain.schedule.service.ScheduleService;
 import com.example.scheduo.global.auth.annotation.RequestMember;
 import com.example.scheduo.global.response.ApiResponse;
@@ -29,6 +32,16 @@ public class ScheduleController {
 	) {
 		scheduleService.createSchedule(request, member, calendarId);
 		return ApiResponse.onSuccess();
+	}
+
+	@GetMapping("/calendars/{calendarId}/schedules/monthly")
+	public ApiResponse<ScheduleResponseDto.SchedulesByMonthly> getScheduleByMonthly(
+		@RequestMember Member member,
+		@PathVariable("calendarId") Long calendarId,
+		@RequestParam("date") String date
+	) {
+		ScheduleResponseDto.SchedulesByMonthly res = scheduleService.getScheduleByMonthly(member, calendarId, date);
+		return ApiResponse.onSuccess(res);
 	}
 
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -40,7 +40,7 @@ public class ScheduleController {
 		@PathVariable("calendarId") Long calendarId,
 		@RequestParam("date") String date
 	) {
-		ScheduleResponseDto.SchedulesByMonthly res = scheduleService.getScheduleByMonthly(member, calendarId, date);
+		ScheduleResponseDto.SchedulesByMonthly res = scheduleService.getSchedulesByMonth(member, calendarId, date);
 		return ApiResponse.onSuccess(res);
 	}
 

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
@@ -1,0 +1,39 @@
+package com.example.scheduo.domain.schedule.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.example.scheduo.domain.schedule.entity.Color;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ScheduleResponseDto {
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class SchedulesByMonthly {
+		private Long calendarId;
+		List<Schedule> schedules;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Schedule {
+		private Long id;
+		private String title;
+		private LocalDate startDate;
+		private LocalDate endDate;
+		private Category category;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Category {
+		private String name;
+		private Color color;
+	}
+}

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
@@ -16,6 +16,20 @@ public class ScheduleResponseDto {
 	public static class SchedulesByMonthly {
 		private Long calendarId;
 		List<Schedule> schedules;
+
+		public static SchedulesByMonthly from(Long calendarId,
+			List<com.example.scheduo.domain.schedule.entity.Schedule> schedules) {
+			List<Schedule> scheduleList = schedules.stream()
+				.map(schedule -> new Schedule(
+					schedule.getId(),
+					schedule.getTitle(),
+					schedule.getStartDate(),
+					schedule.getEndDate(),
+					new Category(schedule.getCategory().getName(), schedule.getCategory().getColor())
+				))
+				.toList();
+			return new SchedulesByMonthly(calendarId, scheduleList);
+		}
 	}
 
 	@Getter

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
@@ -1,8 +1,14 @@
 package com.example.scheduo.domain.schedule.entity;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import org.springframework.cglib.core.Local;
+
+import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.transform.recurrence.Frequency;
@@ -38,7 +44,6 @@ public class Recurrence {
 	public static Recurrence create(String recurrenceRule, String recurrenceEndDate) {
 		LocalDate recurrenceEndLocalDate = LocalDate.parse(recurrenceEndDate);
 		RRule<LocalDate> rRule = createRRule(recurrenceRule, recurrenceEndLocalDate);
-		System.out.println("Recurrence Rule: " + rRule);
 		return Recurrence.builder()
 			.recurrenceRule(rRule.toString())
 			.recurrenceEndDate(recurrenceEndLocalDate)
@@ -57,10 +62,44 @@ public class Recurrence {
 		return new RRule<>(recur);
 	}
 
-	public List<LocalDate> createRecurDates(LocalDate startDate) {
-		String cleanedRecurrenceRule = this.recurrenceRule.replaceFirst("^RRULE:\\s*", "").trim();
-		RRule rRule = new RRule(cleanedRecurrenceRule);
-		Recur<LocalDate> recur = rRule.getRecur();
-		return recur.getDates(startDate, this.recurrenceEndDate).stream().toList();
+	/**
+	 * {
+	 *     [
+	 *     	{
+	 *     	   "startDate": ~~,
+	 *	    	"endDate": ~~
+	 *     	},
+	 *     	~~
+	 *     ]
+	 * }
+	 */
+	// TODO: 일정 생성 구현 필요
+	public List<RecurDate> createRecurDates(LocalDate startDate, LocalDate endDate) {
+		RRule<LocalDate> rrule = new RRule<>(this.recurrenceRule);
+		Recur<LocalDate> recur = rrule.getRecur();
+
+		// recur.getDates(
+		// 	startDate,
+		// 	startDate,
+		// 	endDate
+		// ).stream()
+		// 	.map(date -> ((Date)date)
+		// 		.toInstant()
+		// 		.atZone(ZoneId.systemDefault())
+		// 		.toLocalDate())
+		// 	.collect(Collectors.toList());
+
+		return null;
+	}
+
+	protected static class RecurDate {
+		private final LocalDate startDate;
+		private final LocalDate endDate;
+
+		public RecurDate(LocalDate startDate, LocalDate endDate) {
+			this.startDate = startDate;
+			this.endDate = endDate;
+		}
+
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
@@ -1,14 +1,8 @@
 package com.example.scheduo.domain.schedule.entity;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.temporal.Temporal;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.springframework.cglib.core.Local;
-
-import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.transform.recurrence.Frequency;
@@ -44,6 +38,7 @@ public class Recurrence {
 	public static Recurrence create(String recurrenceRule, String recurrenceEndDate) {
 		LocalDate recurrenceEndLocalDate = LocalDate.parse(recurrenceEndDate);
 		RRule<LocalDate> rRule = createRRule(recurrenceRule, recurrenceEndLocalDate);
+		System.out.println("Recurrence Rule: " + rRule);
 		return Recurrence.builder()
 			.recurrenceRule(rRule.toString())
 			.recurrenceEndDate(recurrenceEndLocalDate)
@@ -62,44 +57,10 @@ public class Recurrence {
 		return new RRule<>(recur);
 	}
 
-	/**
-	 * {
-	 *     [
-	 *     	{
-	 *     	   "startDate": ~~,
-	 *	    	"endDate": ~~
-	 *     	},
-	 *     	~~
-	 *     ]
-	 * }
-	 */
-	// TODO: 일정 생성 구현 필요
-	public List<RecurDate> createRecurDates(LocalDate startDate, LocalDate endDate) {
-		RRule<LocalDate> rrule = new RRule<>(this.recurrenceRule);
-		Recur<LocalDate> recur = rrule.getRecur();
-
-		// recur.getDates(
-		// 	startDate,
-		// 	startDate,
-		// 	endDate
-		// ).stream()
-		// 	.map(date -> ((Date)date)
-		// 		.toInstant()
-		// 		.atZone(ZoneId.systemDefault())
-		// 		.toLocalDate())
-		// 	.collect(Collectors.toList());
-
-		return null;
-	}
-
-	protected static class RecurDate {
-		private final LocalDate startDate;
-		private final LocalDate endDate;
-
-		public RecurDate(LocalDate startDate, LocalDate endDate) {
-			this.startDate = startDate;
-			this.endDate = endDate;
-		}
-
+	public List<LocalDate> createRecurDates(LocalDate startDate) {
+		String cleanedRecurrenceRule = this.recurrenceRule.replaceFirst("^RRULE:\\s*", "").trim();
+		RRule rRule = new RRule(cleanedRecurrenceRule);
+		Recur<LocalDate> recur = rRule.getRecur();
+		return recur.getDates(startDate, this.recurrenceEndDate).stream().toList();
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
@@ -1,14 +1,8 @@
 package com.example.scheduo.domain.schedule.entity;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.temporal.Temporal;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.springframework.cglib.core.Local;
-
-import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.transform.recurrence.Frequency;
@@ -62,34 +56,12 @@ public class Recurrence {
 		return new RRule<>(recur);
 	}
 
-	/**
-	 * {
-	 *     [
-	 *     	{
-	 *     	   "startDate": ~~,
-	 *	    	"endDate": ~~
-	 *     	},
-	 *     	~~
-	 *     ]
-	 * }
-	 */
-	// TODO: 일정 생성 구현 필요
-	public List<RecurDate> createRecurDates(LocalDate startDate, LocalDate endDate) {
-		RRule<LocalDate> rrule = new RRule<>(this.recurrenceRule);
+	public List<LocalDate> createRecurDates(LocalDate startDate) {
+		String recurrenceRule = this.recurrenceRule.replaceFirst("^RRULE:\\s*", "").trim();
+		RRule<LocalDate> rrule = new RRule<>(recurrenceRule);
 		Recur<LocalDate> recur = rrule.getRecur();
 
-		// recur.getDates(
-		// 	startDate,
-		// 	startDate,
-		// 	endDate
-		// ).stream()
-		// 	.map(date -> ((Date)date)
-		// 		.toInstant()
-		// 		.atZone(ZoneId.systemDefault())
-		// 		.toLocalDate())
-		// 	.collect(Collectors.toList());
-
-		return null;
+		return recur.getDates(startDate, this.recurrenceEndDate);
 	}
 
 	protected static class RecurDate {

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
@@ -1,7 +1,14 @@
 package com.example.scheduo.domain.schedule.entity;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.springframework.cglib.core.Local;
+
+import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.Recur;
 import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.transform.recurrence.Frequency;
@@ -55,4 +62,44 @@ public class Recurrence {
 		return new RRule<>(recur);
 	}
 
+	/**
+	 * {
+	 *     [
+	 *     	{
+	 *     	   "startDate": ~~,
+	 *	    	"endDate": ~~
+	 *     	},
+	 *     	~~
+	 *     ]
+	 * }
+	 */
+	// TODO: 일정 생성 구현 필요
+	public List<RecurDate> createRecurDates(LocalDate startDate, LocalDate endDate) {
+		RRule<LocalDate> rrule = new RRule<>(this.recurrenceRule);
+		Recur<LocalDate> recur = rrule.getRecur();
+
+		// recur.getDates(
+		// 	startDate,
+		// 	startDate,
+		// 	endDate
+		// ).stream()
+		// 	.map(date -> ((Date)date)
+		// 		.toInstant()
+		// 		.atZone(ZoneId.systemDefault())
+		// 		.toLocalDate())
+		// 	.collect(Collectors.toList());
+
+		return null;
+	}
+
+	protected static class RecurDate {
+		private final LocalDate startDate;
+		private final LocalDate endDate;
+
+		public RecurDate(LocalDate startDate, LocalDate endDate) {
+			this.startDate = startDate;
+			this.endDate = endDate;
+		}
+
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
@@ -2,6 +2,7 @@ package com.example.scheduo.domain.schedule.entity;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.Period;
 import java.util.List;
 
 import org.hibernate.annotations.OnDelete;
@@ -120,8 +121,29 @@ public class Schedule extends BaseEntity {
 	}
 
 	// TODO: 각각 스케쥴 별로 create recurrence 함수 호출
-	public static List<Schedule> createSchedulesFromRecurrence(List<Schedule> schedulesWithRecurrence) {
-		// 다 돌면서 일정 생성 해줘야함
-		return null;
+	public List<Schedule> createSchedulesFromRecurrence() {
+		if (recurrence == null) {
+			return List.of(this);
+		}
+		Period duration = Period.between(startDate, endDate);
+
+		return recurrence.createRecurDates(startDate).stream()
+			.map(date -> Schedule.builder()
+				.id(id)
+				.title(title)
+				.isAllDay(isAllDay)
+				.startDate(date)
+				.endDate(date.plus(duration))
+				.startTime(startTime)
+				.endTime(endTime)
+				.location(location)
+				.memo(memo)
+				.notificationTime(notificationTime)
+				.category(category)
+				.member(member)
+				.calendar(calendar)
+				.recurrence(recurrence)
+				.build())
+			.toList();
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
@@ -83,7 +83,7 @@ public class Schedule extends BaseEntity {
 	@JoinColumn(name = "calendarId")
 	private Calendar calendar;
 
-	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "recurrenceId")
 	private Recurrence recurrence;
 

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
@@ -2,6 +2,7 @@ package com.example.scheduo.domain.schedule.entity;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
@@ -116,5 +117,11 @@ public class Schedule extends BaseEntity {
 			.calendar(calendar)
 			.recurrence(recurrence)
 			.build();
+	}
+
+	// TODO: 각각 스케쥴 별로 create recurrence 함수 호출
+	public static List<Schedule> createSchedulesFromRecurrence(List<Schedule> schedulesWithRecurrence) {
+		// 다 돌면서 일정 생성 해줘야함
+		return null;
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/RecurrenceRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/RecurrenceRepository.java
@@ -1,8 +1,11 @@
 package com.example.scheduo.domain.schedule.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.scheduo.domain.schedule.entity.Recurrence;
 
 public interface RecurrenceRepository extends JpaRepository<Recurrence, Long> {
+	List<Recurrence> findByRecurrenceEndDate();
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/RecurrenceRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/RecurrenceRepository.java
@@ -1,11 +1,8 @@
 package com.example.scheduo.domain.schedule.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.scheduo.domain.schedule.entity.Recurrence;
 
 public interface RecurrenceRepository extends JpaRepository<Recurrence, Long> {
-	List<Recurrence> findByRecurrenceEndDate();
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -7,7 +7,7 @@ import com.example.scheduo.domain.schedule.entity.Schedule;
 
 public interface ScheduleJpqlRepository {
 	// 월별 일정(반복 x) 조회
-	List<Schedule> findSchedulesByStartMonthAndEndMonth(int month, long calendarId);
+	List<Schedule> findSchedulesByStartMonthAndEndMonth(int year, int month, long calendarId);
 
 	// 반복 일정 중 조회 유효한 일정 조회
 	List<Schedule> findSchedulesWithRecurrence(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth, long calendarId);

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -1,14 +1,13 @@
 package com.example.scheduo.domain.schedule.repository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import com.example.scheduo.domain.schedule.entity.Schedule;
 
 public interface ScheduleJpqlRepository {
 	// 월별 일정(반복 x) 조회
-	List<Schedule> findSchedulesByStartMonthAndEndMonth(int month, long calendarId);
+	List<Schedule> findSchedulesByStartMonthAndEndMonth(int month);
 
 	// 반복 일정 중 조회 유효한 일정 조회
-	List<Schedule> findSchedulesWithRecurrence(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth, long calendarId);
+	List<Schedule> findSchedulesWithRecurrence(int month);
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -1,0 +1,10 @@
+package com.example.scheduo.domain.schedule.repository;
+
+import java.util.List;
+
+import com.example.scheduo.domain.schedule.entity.Schedule;
+
+public interface ScheduleJpqlRepository {
+	// 월별 일정 조회
+	List<Schedule> findSchedulesByStartMonthAndEndMonth(String date);
+}

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -5,6 +5,9 @@ import java.util.List;
 import com.example.scheduo.domain.schedule.entity.Schedule;
 
 public interface ScheduleJpqlRepository {
-	// 월별 일정 조회
-	List<Schedule> findSchedulesByStartMonthAndEndMonth(String date);
+	// 월별 일정(반복 x) 조회
+	List<Schedule> findSchedulesByStartMonthAndEndMonth(int month);
+
+	// 반복 일정 중 조회 유효한 일정 조회
+	List<Schedule> findSchedulesWithRecurrence(int month);
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -1,13 +1,14 @@
 package com.example.scheduo.domain.schedule.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import com.example.scheduo.domain.schedule.entity.Schedule;
 
 public interface ScheduleJpqlRepository {
 	// 월별 일정(반복 x) 조회
-	List<Schedule> findSchedulesByStartMonthAndEndMonth(int month);
+	List<Schedule> findSchedulesByStartMonthAndEndMonth(int month, long calendarId);
 
 	// 반복 일정 중 조회 유효한 일정 조회
-	List<Schedule> findSchedulesWithRecurrence(int month);
+	List<Schedule> findSchedulesWithRecurrence(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth, long calendarId);
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.scheduo.domain.schedule.entity.Schedule;
 
-public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleJpqlRepository {
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -17,16 +17,18 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 	private EntityManager entityManager;
 
 	@Override
-	public List<Schedule> findSchedulesByStartMonthAndEndMonth(int month, long calendarId) {
+	public List<Schedule> findSchedulesByStartMonthAndEndMonth(int year, int month, long calendarId) {
 		String jpql = """
 			SELECT s FROM Schedule s
 			JOIN FETCH s.category c
 			WHERE c.id = s.category.id
-			AND (MONTH(s.startDate) = :month OR MONTH(s.endDate) = :month)
+			AND ((YEAR(s.startDate) = :year AND MONTH(s.startDate) = :month)
+			 OR (YEAR(s.endDate) = :year AND MONTH(s.endDate) = :month))
 			AND s.recurrence is null
 			AND s.calendar.id = :calendarId
 			""";
 		return entityManager.createQuery(jpql, Schedule.class)
+			.setParameter("year", year)
 			.setParameter("month", month)
 			.setParameter("calendarId", calendarId)
 			.getResultList();

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.example.scheduo.domain.schedule.repository.impl;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.example.scheduo.domain.schedule.entity.Schedule;
+import com.example.scheduo.domain.schedule.repository.ScheduleJpqlRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Repository
+public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Override
+	public List<Schedule> findSchedulesByStartMonthAndEndMonth(String month){
+		String jpql = """
+			SELECT s FROM Schedule s
+			WHERE MONTH(s.startDate) = :month OR MONTH(s.endDate) = :date
+			""";
+		return entityManager.createQuery(jpql, Schedule.class)
+			.setParameter("month", month)
+			.getResultList();
+	}
+}

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -20,7 +20,9 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 	public List<Schedule> findSchedulesByStartMonthAndEndMonth(int month, long calendarId) {
 		String jpql = """
 			SELECT s FROM Schedule s
-			WHERE (MONTH(s.startDate) = :month OR MONTH(s.endDate) = :month)
+			JOIN FETCH s.category c
+			WHERE c.id = s.category.id
+			AND (MONTH(s.startDate) = :month OR MONTH(s.endDate) = :month)
 			AND s.recurrence is null
 			AND s.calendar.id = :calendarId
 			""";
@@ -36,6 +38,7 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 		String jpql = """
 				SELECT DISTINCT s FROM Schedule s
 				JOIN FETCH s.recurrence r
+				JOIN FETCH s.category c
 				WHERE r.recurrenceEndDate >= :startOfMonth
 				AND s.startDate <= :endOfMonth
 				AND s.calendar.id = :calendarId

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -1,8 +1,8 @@
 package com.example.scheduo.domain.schedule.repository.impl;
 
+import java.time.LocalDate;
 import java.util.List;
 
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.example.scheduo.domain.schedule.entity.Schedule;
@@ -17,28 +17,34 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 	private EntityManager entityManager;
 
 	@Override
-	public List<Schedule> findSchedulesByStartMonthAndEndMonth(int month){
+	public List<Schedule> findSchedulesByStartMonthAndEndMonth(int month, long calendarId) {
 		String jpql = """
 			SELECT s FROM Schedule s
-			WHERE MONTH(s.startDate) = :month OR MONTH(s.endDate) = :date
+			WHERE (MONTH(s.startDate) = :month OR MONTH(s.endDate) = :month)
 			AND s.recurrence is null
+			AND s.calendar.id = :calendarId
 			""";
 		return entityManager.createQuery(jpql, Schedule.class)
 			.setParameter("month", month)
+			.setParameter("calendarId", calendarId)
 			.getResultList();
 	}
 
 	@Override
-	public List<Schedule> findSchedulesWithRecurrence(int month) {
+	public List<Schedule> findSchedulesWithRecurrence(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth,
+		long calendarId) {
 		String jpql = """
-   			SELECT s FROM Schedule s
-   			JOIN FETCH s.recurrence r
-   			WHERE MONTH(r.recurrenceEndDate) >= :month
-   			AND MONTH(s.startDate) <= :month
+				SELECT DISTINCT s FROM Schedule s
+				JOIN FETCH s.recurrence r
+				WHERE r.recurrenceEndDate >= :startOfMonth
+				AND s.startDate <= :endOfMonth
+				AND s.calendar.id = :calendarId
 			""";
 
 		return entityManager.createQuery(jpql, Schedule.class)
-			.setParameter("month", month)
+			.setParameter("startOfMonth", firstDayOfMonth)
+			.setParameter("endOfMonth", lastDayOfMonth)
+			.setParameter("calendarId", calendarId)
 			.getResultList();
 	}
 

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -17,13 +17,29 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 	private EntityManager entityManager;
 
 	@Override
-	public List<Schedule> findSchedulesByStartMonthAndEndMonth(String month){
+	public List<Schedule> findSchedulesByStartMonthAndEndMonth(int month){
 		String jpql = """
 			SELECT s FROM Schedule s
 			WHERE MONTH(s.startDate) = :month OR MONTH(s.endDate) = :date
+			AND s.recurrence is null
 			""";
 		return entityManager.createQuery(jpql, Schedule.class)
 			.setParameter("month", month)
 			.getResultList();
 	}
+
+	@Override
+	public List<Schedule> findSchedulesWithRecurrence(int month) {
+		String jpql = """
+   			SELECT s FROM Schedule s
+   			JOIN FETCH s.recurrence r
+   			WHERE MONTH(r.recurrenceEndDate) >= :month
+   			AND MONTH(s.startDate) <= :month
+			""";
+
+		return entityManager.createQuery(jpql, Schedule.class)
+			.setParameter("month", month)
+			.getResultList();
+	}
+
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -123,8 +123,9 @@ public class ScheduleServiceImpl implements ScheduleService {
 
 		// DATE to MONTH 파싱 로직
 		// 1. start || end를 기준으로 가져옴, 여러날 일정을 만듬, 만약 그 달에 속하지 않는다면 거름..?
+		int year = LocalDate.parse(date).getYear();
 		int month = LocalDate.parse(date).getMonthValue();
-		List<Schedule> schedulesInSingle = scheduleRepository.findSchedulesByStartMonthAndEndMonth(month, calendarId);
+		List<Schedule> schedulesInSingle = scheduleRepository.findSchedulesByStartMonthAndEndMonth(year, month, calendarId);
 
 		// recurrence에서 enddate를 기준으로 지나지 않은 일정 조회
 		LocalDate firstDayOfMonth = LocalDate.parse(date).withDayOfMonth(1);
@@ -138,8 +139,13 @@ public class ScheduleServiceImpl implements ScheduleService {
 			schedulesWithRecurrence.stream().flatMap(s -> s.createSchedulesFromRecurrence().stream())
 		).toList();
 
+		// List<Schedule> filteredSchedules = new ArrayList<>(allSchedules.stream()
+		// 	.filter(s -> s.getStartDate().getMonthValue() == month || s.getEndDate().getMonthValue() == month)
+		// 	.toList());
+
 		List<Schedule> filteredSchedules = new ArrayList<>(allSchedules.stream()
-			.filter(s -> s.getStartDate().getMonthValue() == month || s.getEndDate().getMonthValue() == month)
+			.filter(s -> (s.getStartDate().getYear() == year && s.getStartDate().getMonthValue() == month) ||
+				(s.getEndDate().getYear() == year && s.getEndDate().getMonthValue() == month))
 			.toList());
 
 		// filteredSchedules.sort((s1, s2) -> {

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.scheduo.domain.schedule.service.Impl;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,6 +9,7 @@ import com.example.scheduo.domain.calendar.entity.Calendar;
 import com.example.scheduo.domain.calendar.repository.CalendarRepository;
 import com.example.scheduo.domain.member.entity.Member;
 import com.example.scheduo.domain.schedule.dto.ScheduleRequestDto;
+import com.example.scheduo.domain.schedule.dto.ScheduleResponseDto;
 import com.example.scheduo.domain.schedule.entity.Category;
 import com.example.scheduo.domain.schedule.entity.Recurrence;
 import com.example.scheduo.domain.schedule.entity.Schedule;
@@ -60,5 +63,30 @@ public class ScheduleServiceImpl implements ScheduleService {
 		);
 
 		scheduleRepository.save(schedule);
+	}
+
+	@Override
+	public ScheduleResponseDto.SchedulesByMonthly getScheduleByMonthly(Member member, Long calendarId, String date) {
+		/**
+		 * 로직 => 월별조회
+		 * 1. 캘린더에 멤버가 속해있는지 검증
+		 * 2. month에 대한 schedule db 쿼리 날리기
+		 * 3. 단일 일정 조회
+		 * 4. 반복 일저 조회 -> 직접 일정을 생성
+		 */
+		// 캘린더 조회
+		Calendar calendar = calendarRepository.findById(calendarId)
+			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
+
+		// 멤버가 캘린더에 속해있는지 검증
+		if(calendar.validateParticipant(member.getId()))
+			throw new ApiException(ResponseStatus.PARTICIPANT_PERMISSION_LEAK);
+
+		// DATE to MONTH 파싱 로직
+		// 1. start || end를 기준으로 가져옴, 여러날 일정을 만듬, 만약 그 달에 속하지 않는다면 거름..?
+
+		List<Schedule> schedules = scheduleRepository.findSchedulesByStartMonthAndEndMonth(date);
+
+		return null;
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -76,7 +76,8 @@ public class ScheduleServiceImpl implements ScheduleService {
 		 * 1. 캘린더에 멤버가 속해있는지 검증
 		 * 2. month에 대한 schedule db 쿼리 날리기
 		 * 3. 단일 일정 조회
-		 * 4. 반복 일저 조회 -> 직접 일정을 생성
+		 * 4. 반복 일정 조회 -> 직접 일정을 생성
+		 * 5. 예외 조건 추가
 		 */
 		// 캘린더 조회
 		Calendar calendar = calendarRepository.findByIdWithParticipants(calendarId)
@@ -107,12 +108,12 @@ public class ScheduleServiceImpl implements ScheduleService {
 			.filter(s -> s.getStartDate().getMonthValue() == month || s.getEndDate().getMonthValue() == month)
 			.toList());
 
-		filteredSchedules.sort((s1, s2) -> {
-			if (s1.getStartDate().equals(s2.getStartDate())) {
-				return s1.getStartTime().compareTo(s2.getStartTime());
-			}
-			return s1.getStartDate().compareTo(s2.getStartDate());
-		});
+		// filteredSchedules.sort((s1, s2) -> {
+		// 	if (s1.getStartDate().equals(s2.getStartDate())) {
+		// 		return s1.getStartTime().compareTo(s2.getStartTime());
+		// 	}
+		// 	return s1.getStartDate().compareTo(s2.getStartDate());
+		// });
 
 		return ScheduleResponseDto.SchedulesByMonthly.from(calendarId, filteredSchedules);
 	}

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.scheduo.domain.schedule.service.Impl;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -65,6 +66,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 		scheduleRepository.save(schedule);
 	}
 
+	// TODO: 월별 조회 일정 로직 구현 필요
 	@Override
 	public ScheduleResponseDto.SchedulesByMonthly getScheduleByMonthly(Member member, Long calendarId, String date) {
 		/**
@@ -84,8 +86,14 @@ public class ScheduleServiceImpl implements ScheduleService {
 
 		// DATE to MONTH 파싱 로직
 		// 1. start || end를 기준으로 가져옴, 여러날 일정을 만듬, 만약 그 달에 속하지 않는다면 거름..?
+		int month = LocalDate.parse(date).getMonthValue();
+		List<Schedule> schedulesInSingle = scheduleRepository.findSchedulesByStartMonthAndEndMonth(month);
 
-		List<Schedule> schedules = scheduleRepository.findSchedulesByStartMonthAndEndMonth(date);
+		// recurrence에서 enddate를 기준으로 지나지 않은 일정 조회
+		List<Schedule> schedulesWithRecurrence = scheduleRepository.findSchedulesWithRecurrence(month);
+
+		// recurrence 인스턴스 일정 생성
+		// schedule.XXX(schedulesWithRecurrence);
 
 		return null;
 	}

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -17,6 +17,7 @@ import com.example.scheduo.domain.schedule.entity.Category;
 import com.example.scheduo.domain.schedule.entity.Recurrence;
 import com.example.scheduo.domain.schedule.entity.Schedule;
 import com.example.scheduo.domain.schedule.repository.CategoryRepository;
+import com.example.scheduo.domain.schedule.repository.RecurrenceRepository;
 import com.example.scheduo.domain.schedule.repository.ScheduleRepository;
 import com.example.scheduo.domain.schedule.service.ScheduleService;
 import com.example.scheduo.global.response.exception.ApiException;
@@ -31,6 +32,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 	private final ScheduleRepository scheduleRepository;
 	private final CategoryRepository categoryRepository;
 	private final CalendarRepository calendarRepository;
+	private final RecurrenceRepository recurrenceRepository;
 
 	@Override
 	@Transactional
@@ -47,6 +49,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 				request.getRecurrence().getFrequency(),
 				request.getRecurrence().getRecurrenceEndDate()
 			);
+			recurrence = recurrenceRepository.save(recurrence);
 		}
 
 		Schedule schedule = Schedule.create(

--- a/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
@@ -7,5 +7,5 @@ import com.example.scheduo.domain.schedule.dto.ScheduleResponseDto;
 public interface ScheduleService {
 	void createSchedule(ScheduleRequestDto.Create request, Member member, Long calendarId);
 
-	ScheduleResponseDto.SchedulesByMonthly getScheduleByMonthly(Member member, Long calendarId, String date);
+	ScheduleResponseDto.SchedulesByMonthly getSchedulesByMonth(Member member, Long calendarId, String date);
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
@@ -2,7 +2,10 @@ package com.example.scheduo.domain.schedule.service;
 
 import com.example.scheduo.domain.member.entity.Member;
 import com.example.scheduo.domain.schedule.dto.ScheduleRequestDto;
+import com.example.scheduo.domain.schedule.dto.ScheduleResponseDto;
 
 public interface ScheduleService {
 	void createSchedule(ScheduleRequestDto.Create request, Member member, Long calendarId);
+
+	ScheduleResponseDto.SchedulesByMonthly getScheduleByMonthly(Member member, Long calendarId, String date);
 }

--- a/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
+++ b/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
@@ -58,6 +58,7 @@ public enum ResponseStatus {
 	PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTICIPANT4001", "참여자를 찾을 수 없습니다."),
 	PARTICIPANT_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, "PARTICIPANT4002", "초대를 수락한 참여자만 권한을 수정할 수 있습니다."),
 	CANNOT_REMOVE_OWNER(HttpStatus.BAD_REQUEST, "PARTICIPANT4003", "오너는 캘린더에서 내보낼 수 없습니다."),
+	PARTICIPANT_PERMISSION_LEAK(HttpStatus.FORBIDDEN, "PARTICIPANT4004", "참여자의 권한이 부족합니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/kotlin/com/example/scheduo/fixture/RecurrenceFixture.kt
+++ b/src/test/kotlin/com/example/scheduo/fixture/RecurrenceFixture.kt
@@ -1,0 +1,11 @@
+package com.example.scheduo.fixture
+
+import com.example.scheduo.domain.schedule.entity.Recurrence
+
+fun createRecurrence(
+        frequency: String = "WEEKLY",
+        recurrenceEndDate: String = "2025-12-31"
+) = Recurrence.create(
+        frequency,
+        recurrenceEndDate
+)

--- a/src/test/kotlin/com/example/scheduo/fixture/ScheduleFixture.kt
+++ b/src/test/kotlin/com/example/scheduo/fixture/ScheduleFixture.kt
@@ -1,0 +1,37 @@
+package com.example.scheduo.fixture
+
+import com.example.scheduo.domain.calendar.entity.Calendar
+import com.example.scheduo.domain.member.entity.Member
+import com.example.scheduo.domain.schedule.entity.Category
+import com.example.scheduo.domain.schedule.entity.NotificationTime
+import com.example.scheduo.domain.schedule.entity.Recurrence
+import com.example.scheduo.domain.schedule.entity.Schedule
+
+fun createSchedule(
+        title: String = "테스트 일정",
+        startDate: String = "2025-07-01",
+        endDate: String = "2025-07-01",
+        startTime: String = "09:00",
+        endTime: String = "10:00",
+        isAllDay: Boolean = false,
+        location: String = "회의실",
+        memo: String = "테스트 메모",
+        member: Member,
+        calendar: Calendar,
+        category: Category,
+        recurrence: Recurrence? = null
+) = Schedule.create(
+        title,
+        isAllDay,
+        startDate,
+        endDate,
+        startTime,
+        endTime,
+        location,
+        memo,
+        NotificationTime.ONE_DAY_BEFORE,
+        category,
+        member,
+        calendar,
+        recurrence
+)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
#72  

## 🎁 작업 내용
- 월별 일정 조회 기능 ( year과 month가 속해있으면 조회 )
 - 단일일정(쿼리 필터링) || 반복일정(애플리케이션 필터링)
- Schedule과 Recurrence의 생명주기 결합 제거(cascade)
- 정상 경계 값 테스트 코드 작성