### PR TITLE
캘린더 생성 시 초대 생성

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
@@ -43,6 +43,12 @@ public class Calendar extends BaseEntity {
 		participant.setCalendar(this);
 	}
 
+	public void addParticipants(List<Participant> participants) {
+		for (Participant participant : participants) {
+			this.addParticipant(participant);
+		}
+	}
+
 	public void updateTitle(String title) {
 		this.name = title;
 	}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #84 

## 🎁 작업 내용
- 사용자가 캘린더를 생성하면서 참여자를 추가하면, 참여자들에게 초대 알림이 가도록 수정
- 테스트 코드도 2가지 케이스로 분리해서 검증, 참여자가 있는 경우와 없는 경우