### PR TITLE
[Feat] 특정 캘린더 + 특정 날짜 일정 조회 api 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -52,7 +52,8 @@ public class ScheduleController {
 		@PathVariable("calendarId") Long calendarId,
 		@RequestParam("date") String date
 	) {
-		return ApiResponse.onSuccess();
+		ScheduleResponseDto.SchedulesOnDate res = scheduleService.getSchedulesOnDate(member, calendarId, date);
+		return ApiResponse.onSuccess(res);
 	}
 
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -37,7 +37,7 @@ public class ScheduleController {
 	}
 
 	@GetMapping("/calendars/{calendarId}/schedules/monthly")
-	public ApiResponse<ScheduleResponseDto.SchedulesOnMonth> getScheduleByMonthly(
+	public ApiResponse<ScheduleResponseDto.SchedulesOnMonth> getScheduleOnMonth(
 		@RequestMember Member member,
 		@PathVariable("calendarId") Long calendarId,
 		@RequestParam("date") String date
@@ -47,7 +47,7 @@ public class ScheduleController {
 	}
 
 	@GetMapping("/calendars/{calendarId}/schedules")
-	public ApiResponse<ScheduleResponseDto.SchedulesOnDate> getScheduleOnDateInCalendar(
+	public ApiResponse<ScheduleResponseDto.SchedulesOnDate> getScheduleOnDate(
 		@RequestMember Member member,
 		@PathVariable("calendarId") Long calendarId,
 		@RequestParam("date") String date

--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -37,13 +37,22 @@ public class ScheduleController {
 	}
 
 	@GetMapping("/calendars/{calendarId}/schedules/monthly")
-	public ApiResponse<ScheduleResponseDto.SchedulesByMonthly> getScheduleByMonthly(
+	public ApiResponse<ScheduleResponseDto.SchedulesOnMonth> getScheduleByMonthly(
 		@RequestMember Member member,
 		@PathVariable("calendarId") Long calendarId,
 		@RequestParam("date") String date
 	) {
-		ScheduleResponseDto.SchedulesByMonthly res = scheduleService.getSchedulesByMonth(member, calendarId, date);
+		ScheduleResponseDto.SchedulesOnMonth res = scheduleService.getSchedulesOnMonth(member, calendarId, date);
 		return ApiResponse.onSuccess(res);
+	}
+
+	@GetMapping("/calendars/{calendarId}/schedules")
+	public ApiResponse<ScheduleResponseDto.SchedulesOnDate> getScheduleOnDateInCalendar(
+		@RequestMember Member member,
+		@PathVariable("calendarId") Long calendarId,
+		@RequestParam("date") String date
+	) {
+		return ApiResponse.onSuccess();
 	}
 
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
@@ -1,9 +1,12 @@
 package com.example.scheduo.domain.schedule.dto;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.example.scheduo.domain.schedule.entity.Color;
+import com.example.scheduo.domain.schedule.entity.Schedule;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -36,11 +39,19 @@ public class ScheduleResponseDto {
 	@NoArgsConstructor
 	@AllArgsConstructor
 	public static class SchedulesOnDate {
-		List<ScheduleOnMonth> schedules;
+		List<ScheduleOnDate> schedules;
+
+		public static SchedulesOnDate from(List<Schedule> schedules) {
+			List<ScheduleOnDate> scheduleOnDates = schedules.stream()
+				.map(ScheduleOnDate::from)
+				.collect(Collectors.toList());
+
+			return new SchedulesOnDate(scheduleOnDates);
+		}
 	}
 
 
-		@Getter
+	@Getter
 	@NoArgsConstructor
 	@AllArgsConstructor
 	private static class ScheduleOnMonth {
@@ -57,10 +68,21 @@ public class ScheduleResponseDto {
 	private static class ScheduleOnDate {
 		private Long id;
 		private String title;
-		private LocalDate startTime;
-		private LocalDate endTime;
+		private LocalTime startTime;
+		private LocalTime endTime;
 		private boolean isAllDay;
 		private Category category;
+
+		public static ScheduleOnDate from(Schedule schedule) {
+			return new ScheduleOnDate(
+				schedule.getId(),
+				schedule.getTitle(),
+				schedule.getStartTime(),
+				schedule.getEndTime(),
+				schedule.isAllDay(),
+				Category.from(schedule.getCategory().getName(), schedule.getCategory().getColor())
+			);
+		}
 	}
 
 	@Getter
@@ -69,5 +91,9 @@ public class ScheduleResponseDto {
 	private static class Category {
 		private String name;
 		private Color color;
+
+		public static Category from(String name, Color color) {
+			return new Category(name, color);
+		}
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
@@ -13,14 +13,14 @@ public class ScheduleResponseDto {
 	@Getter
 	@NoArgsConstructor
 	@AllArgsConstructor
-	public static class SchedulesByMonthly {
+	public static class SchedulesOnMonth {
 		private Long calendarId;
-		List<Schedule> schedules;
+		List<ScheduleOnMonth> schedules;
 
-		public static SchedulesByMonthly from(Long calendarId,
+		public static SchedulesOnMonth from(Long calendarId,
 			List<com.example.scheduo.domain.schedule.entity.Schedule> schedules) {
-			List<Schedule> scheduleList = schedules.stream()
-				.map(schedule -> new Schedule(
+			List<ScheduleOnMonth> scheduleList = schedules.stream()
+				.map(schedule -> new ScheduleOnMonth(
 					schedule.getId(),
 					schedule.getTitle(),
 					schedule.getStartDate(),
@@ -28,14 +28,22 @@ public class ScheduleResponseDto {
 					new Category(schedule.getCategory().getName(), schedule.getCategory().getColor())
 				))
 				.toList();
-			return new SchedulesByMonthly(calendarId, scheduleList);
+			return new SchedulesOnMonth(calendarId, scheduleList);
 		}
 	}
 
 	@Getter
 	@NoArgsConstructor
 	@AllArgsConstructor
-	public static class Schedule {
+	public static class SchedulesOnDate {
+		List<ScheduleOnMonth> schedules;
+	}
+
+
+		@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class ScheduleOnMonth {
 		private Long id;
 		private String title;
 		private LocalDate startDate;
@@ -46,7 +54,19 @@ public class ScheduleResponseDto {
 	@Getter
 	@NoArgsConstructor
 	@AllArgsConstructor
-	public static class Category {
+	private static class ScheduleOnDate {
+		private Long id;
+		private String title;
+		private LocalDate startTime;
+		private LocalDate endTime;
+		private boolean isAllDay;
+		private Category category;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	private static class Category {
 		private String name;
 		private Color color;
 	}

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -7,7 +7,7 @@ import com.example.scheduo.domain.schedule.entity.Schedule;
 
 public interface ScheduleJpqlRepository {
 	// 월별 일정(반복 x) 조회
-	List<Schedule> findSchedulesByStartMonthAndEndMonth(int year, int month, long calendarId);
+	List<Schedule> findSchedulesByDateRange(LocalDate startOfMonth, LocalDate endOfMonth, long calendarId);
 
 	// 반복 일정 중 조회 유효한 일정 조회
 	List<Schedule> findSchedulesWithRecurrenceForRange(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth, long calendarId);

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -10,5 +10,11 @@ public interface ScheduleJpqlRepository {
 	List<Schedule> findSchedulesByStartMonthAndEndMonth(int year, int month, long calendarId);
 
 	// 반복 일정 중 조회 유효한 일정 조회
-	List<Schedule> findSchedulesWithRecurrence(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth, long calendarId);
+	List<Schedule> findSchedulesWithRecurrenceForRange(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth, long calendarId);
+
+	//특정 날짜의 단일 일정 조회(반복 x)
+	List<Schedule> findSchedulesByDate(LocalDate date, long calendarId);
+
+	// 특정 날짜에 해당할 수 있는 반복 일정 조회
+	List<Schedule> findSchedulesWithRecurrenceForDate(LocalDate date, long calendarId);
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -21,9 +21,7 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 		String jpql = """
 			SELECT s FROM Schedule s
 			JOIN FETCH s.category c
-			WHERE ((s.startDate >= :startOfMonth AND s.startDate <= :endOfMonth)
-				   OR (s.endDate >= :startOfMonth AND s.endDate <= :endOfMonth)
-				   OR (s.startDate <= :startOfMonth AND s.endDate >= :endOfMonth))
+			WHERE (s.startDate <= :endOfMonth AND s.endDate >= :startOfMonth)
 			AND s.recurrence is null
 			AND s.calendar.id = :calendarId
         	""";

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -17,25 +17,25 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 	private EntityManager entityManager;
 
 	@Override
-	public List<Schedule> findSchedulesByStartMonthAndEndMonth(int year, int month, long calendarId) {
+	public List<Schedule> findSchedulesByDateRange(LocalDate startOfMonth, LocalDate endOfMonth, long calendarId) {
 		String jpql = """
 			SELECT s FROM Schedule s
 			JOIN FETCH s.category c
-			WHERE c.id = s.category.id
-			AND ((YEAR(s.startDate) = :year AND MONTH(s.startDate) = :month)
-			 OR (YEAR(s.endDate) = :year AND MONTH(s.endDate) = :month))
+			WHERE ((s.startDate >= :startOfMonth AND s.startDate <= :endOfMonth)
+				   OR (s.endDate >= :startOfMonth AND s.endDate <= :endOfMonth)
+				   OR (s.startDate <= :startOfMonth AND s.endDate >= :endOfMonth))
 			AND s.recurrence is null
 			AND s.calendar.id = :calendarId
-			""";
+        	""";
 		return entityManager.createQuery(jpql, Schedule.class)
-			.setParameter("year", year)
-			.setParameter("month", month)
+			.setParameter("startOfMonth", startOfMonth)
+			.setParameter("endOfMonth", endOfMonth)
 			.setParameter("calendarId", calendarId)
 			.getResultList();
 	}
 
 	@Override
-	public List<Schedule> findSchedulesWithRecurrence(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth,
+	public List<Schedule> findSchedulesWithRecurrenceForRange(LocalDate firstDayOfMonth, LocalDate lastDayOfMonth,
 		long calendarId) {
 		String jpql = """
 				SELECT DISTINCT s FROM Schedule s

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -53,4 +53,36 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 			.getResultList();
 	}
 
+	@Override
+	public List<Schedule> findSchedulesByDate(LocalDate date, long calendarId) {
+		String jpql = """
+            SELECT s FROM Schedule s
+            JOIN FETCH s.category c
+            WHERE s.startDate <= :date 
+            AND s.endDate >= :date
+            AND s.recurrence is null
+            AND s.calendar.id = :calendarId
+            """;
+		return entityManager.createQuery(jpql, Schedule.class)
+			.setParameter("date", date)
+			.setParameter("calendarId", calendarId)
+			.getResultList();
+	}
+
+	@Override
+	public List<Schedule> findSchedulesWithRecurrenceForDate(LocalDate date, long calendarId) {
+		String jpql = """
+            SELECT DISTINCT s FROM Schedule s
+            JOIN FETCH s.recurrence r
+            JOIN FETCH s.category c
+            WHERE s.startDate <= :date
+            AND (r.recurrenceEndDate IS NULL OR r.recurrenceEndDate >= :date)
+            AND s.calendar.id = :calendarId
+            """;
+		return entityManager.createQuery(jpql, Schedule.class)
+			.setParameter("date", date)
+			.setParameter("calendarId", calendarId)
+			.getResultList();
+	}
+
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -104,7 +104,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 	 */
 
 	@Override
-	public ScheduleResponseDto.SchedulesByMonthly getSchedulesByMonth(Member member, Long calendarId, String date) {
+	public ScheduleResponseDto.SchedulesOnMonth getSchedulesOnMonth(Member member, Long calendarId, String date) {
 		/**
 		 * 로직 => 월별조회
 		 * 1. 캘린더에 멤버가 속해있는지 검증
@@ -155,6 +155,6 @@ public class ScheduleServiceImpl implements ScheduleService {
 		// 	return s1.getStartDate().compareTo(s2.getStartDate());
 		// });
 
-		return ScheduleResponseDto.SchedulesByMonthly.from(calendarId, filteredSchedules);
+		return ScheduleResponseDto.SchedulesOnMonth.from(calendarId, filteredSchedules);
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -192,6 +192,20 @@ public class ScheduleServiceImpl implements ScheduleService {
 			.filter(s -> !s.getStartDate().isAfter(targetDate) && !s.getEndDate().isBefore(targetDate))
 			.collect(Collectors.toList());
 
+		// 타임라인 정렬 로직(기간 > 종일 > 시작시간 > 생성시간)
+		filteredSchedules.sort((s1, s2) -> {
+			// 1. 기간 일정 우선 정렬
+			if (!s1.getStartDate().equals(s2.getStartDate()))
+				return s1.getStartDate().compareTo(s2.getStartDate());
+
+			// 2. 시작 시간 우선 정렬(종일 일정은 시작시간이 00:00:00 이므로 우선순위)
+			if (!s1.getStartTime().equals(s2.getStartTime()))
+				return s1.getStartTime().compareTo(s2.getStartTime());
+
+			// 3. 동점 처리 로직(일정 생성 기준 우선 정렬)
+			return s1.getCreatedAt().compareTo(s2.getCreatedAt());
+		});
+
 		return ScheduleResponseDto.SchedulesOnDate.from(filteredSchedules);
 	}
 

--- a/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
@@ -9,5 +9,5 @@ public interface ScheduleService {
 
 	ScheduleResponseDto.SchedulesOnMonth getSchedulesOnMonth(Member member, Long calendarId, String date);
 
-	ScheduleResponseDto.SchedulesOnDate getSchedulesOnDate();
+	ScheduleResponseDto.SchedulesOnDate getSchedulesOnDate(Member member, Long calendarId, String date);
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
@@ -7,5 +7,7 @@ import com.example.scheduo.domain.schedule.dto.ScheduleResponseDto;
 public interface ScheduleService {
 	void createSchedule(ScheduleRequestDto.Create request, Member member, Long calendarId);
 
-	ScheduleResponseDto.SchedulesByMonthly getSchedulesByMonth(Member member, Long calendarId, String date);
+	ScheduleResponseDto.SchedulesOnMonth getSchedulesOnMonth(Member member, Long calendarId, String date);
+
+	ScheduleResponseDto.SchedulesOnDate getSchedulesOnDate();
 }

--- a/src/test/kotlin/com/example/scheduo/domain/schedule/controller/ScheduleControllerTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/schedule/controller/ScheduleControllerTest.kt
@@ -483,10 +483,9 @@ class ScheduleControllerTest(
                 val schedulesNode = jsonNode.path("data").path("schedules")
                 schedulesNode.size() shouldBe 2
 
-                schedulesNode[0].path("title").asText() shouldBe "아침 회의"
-                schedulesNode[0].path("startTime").asText() shouldBe "09:00:00"
-                schedulesNode[1].path("title").asText() shouldBe "오후 미팅"
-                schedulesNode[1].path("startTime").asText() shouldBe "14:00:00"
+                val scheduleDetails = schedulesNode.map { it.path("title").asText() to it.path("startTime").asText() }
+                scheduleDetails.contains("아침 회의" to "09:00:00") shouldBe true
+                scheduleDetails.contains("오후 미팅" to "14:00:00") shouldBe true
             }
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
#86 


## 🎁 작업 내용
- 특정 캘린더 + 특정 날짜 일정 api 구현
- 월별 단일 일정 조회 쿼리 리팩토링
- 타임라인 기준 정렬로직
  - 기간 일정 > 종일 일정 > 시간 순 > 생성 일자 순(동점처리)