### PR TITLE
:hammer: 초대 API 다중 사용자 지원 및 일부 멤버가 없어도 초대 가능하도록 수정

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/controller/CalendarController.java
@@ -44,7 +44,7 @@ public class CalendarController {
 	public ApiResponse<?> invite(@PathVariable("calendarId") Long calendarId,
 		@RequestBody CalendarRequestDto.Invite request,
 		@RequestMember Member member) {
-		calendarService.inviteMember(calendarId, member, request.getMemberId());
+		calendarService.inviteMembers(calendarId, member, request.getMemberIds());
 		return ApiResponse.onSuccess();
 	}
 

--- a/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarRequestDto.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/dto/CalendarRequestDto.java
@@ -17,7 +17,7 @@ public class CalendarRequestDto {
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class Invite {
-		private Long memberId;
+		private List<Long> memberIds;
 	}
 
 	@Getter

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
@@ -1,11 +1,12 @@
 package com.example.scheduo.domain.calendar.entity;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.example.scheduo.domain.common.BaseEntity;
-import com.example.scheduo.global.response.ApiResponse;
 import com.example.scheduo.global.response.exception.ApiException;
 import com.example.scheduo.global.response.status.ResponseStatus;
 
@@ -71,6 +72,13 @@ public class Calendar extends BaseEntity {
 			.findFirst();
 	}
 
+	public List<Participant> findParticipants(List<Long> memberIds) {
+		Set<Long> sets = new HashSet<>(memberIds);
+		return this.participants.stream()
+			.filter(p -> sets.contains(p.getMember().getId()))
+			.toList();
+	}
+
 	public Optional<Participant> findParticipantById(Long participantId) {
 		return this.participants.stream()
 			.filter(p -> p.getId().equals(participantId))
@@ -119,7 +127,7 @@ public class Calendar extends BaseEntity {
 
 	public boolean validateParticipant(Long memberId) {
 		return this.findParticipant(memberId)
-			.orElseThrow(()-> new ApiException(ResponseStatus.PARTICIPANT_NOT_FOUND))
+			.orElseThrow(() -> new ApiException(ResponseStatus.PARTICIPANT_NOT_FOUND))
 			.isAccepted();
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Participant.java
@@ -58,10 +58,8 @@ public class Participant extends BaseEntity {
 	}
 
 	public void reinvite() {
-		switch (this.status) {
-			case DECLINED -> this.status = ParticipationStatus.PENDING;
-			case PENDING -> throw new ApiException(ResponseStatus.MEMBER_ALREADY_INVITED);
-			case ACCEPTED -> throw new ApiException(ResponseStatus.MEMBER_ALREADY_PARTICIPANT);
+		if (this.status == ParticipationStatus.DECLINED) {
+			this.status = ParticipationStatus.PENDING;
 		}
 	}
 

--- a/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/CalendarService.java
@@ -1,11 +1,13 @@
 package com.example.scheduo.domain.calendar.service;
 
+import java.util.List;
+
 import com.example.scheduo.domain.calendar.dto.CalendarRequestDto;
 import com.example.scheduo.domain.calendar.dto.CalendarResponseDto;
 import com.example.scheduo.domain.member.entity.Member;
 
 public interface CalendarService {
-	void inviteMember(Long calendarId, Member inviter, Long inviteeId);
+	void inviteMembers(Long calendarId, Member inviter, List<Long> inviteeIds);
 
 	void acceptInvitation(Long calendarId, Member member);
 
@@ -19,7 +21,8 @@ public interface CalendarService {
 
 	CalendarResponseDto.CalendarInfoList getCalendars(Member member);
 
-	void updateParticipantRole(Long calendarId, Long participantId, CalendarRequestDto.UpdateParticipantRole request, Long requesterId);
+	void updateParticipantRole(Long calendarId, Long participantId, CalendarRequestDto.UpdateParticipantRole request,
+		Long requesterId);
 
 	void removeParticipant(Long calendarId, Long participantId, Long requesterId);
 

--- a/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/service/impl/CalendarServiceImpl.java
@@ -2,7 +2,9 @@ package com.example.scheduo.domain.calendar.service.impl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -39,7 +41,7 @@ public class CalendarServiceImpl implements CalendarService {
 
 	@Override
 	@Transactional
-	public void inviteMember(Long calendarId, Member inviter, Long inviteeId) {
+	public void inviteMembers(Long calendarId, Member inviter, List<Long> inviteeIds) {
 		Calendar calendar = calendarRepository.findByIdWithParticipants(calendarId)
 			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
 
@@ -47,40 +49,43 @@ public class CalendarServiceImpl implements CalendarService {
 			throw new ApiException(ResponseStatus.MEMBER_NOT_OWNER);
 		}
 
-		Member invitee = memberRepository.findById(inviteeId)
-			.orElseThrow(() -> new ApiException(ResponseStatus.MEMBER_NOT_FOUND));
+		//초대 대상 멤버 조회
+		List<Member> invitees = memberRepository.findAllById(inviteeIds);
 
-		Optional<Participant> existingParticipant = calendar.findParticipant(inviteeId);
+		// 참여자 목록을 Map<Long, Participant>로 변환
+		Map<Long, Participant> participantMap = calendar.getParticipants()
+			.stream()
+			.collect(Collectors.toMap(participant -> participant.getMember().getId(), Function.identity()));
 
-		if (existingParticipant.isPresent()) {
-			existingParticipant.get().reinvite();
-			applicationEventPublisher.publishEvent(
-				CalendarInvitationEvent.builder()
-					.calendarId(calendarId)
-					.calendarName(calendar.getName())
-					.invitee(invitee)
-					.inviterName(calendar.getOwner().getNickname())
-					.build());
-			return;
+		// 모든 초대 대상 처리
+		for (Member member : invitees) {
+			Participant participant = participantMap.get(member.getId());
+			boolean notify;
+			if (participant != null) {
+				participant.reinvite();
+				notify = participant.getStatus() != ParticipationStatus.ACCEPTED;
+			} else {
+				participant = Participant.builder()
+					.calendar(calendar)
+					.nickname(member.getNickname())
+					.member(member)
+					.status(ParticipationStatus.PENDING)
+					.role(Role.VIEW)
+					.build();
+				calendar.addParticipant(participant);
+				notify = true;
+			}
+
+			if (notify) {
+				applicationEventPublisher.publishEvent(
+					CalendarInvitationEvent.builder()
+						.calendarId(calendarId)
+						.calendarName(calendar.getName())
+						.invitee(member)
+						.inviterName(inviter.getNickname())
+						.build());
+			}
 		}
-
-		Participant participant = Participant.builder()
-			.calendar(calendar)
-			.nickname(invitee.getNickname())
-			.member(invitee)
-			.status(ParticipationStatus.PENDING)
-			.role(Role.VIEW)
-			.build();
-
-		calendar.addParticipant(participant);
-
-		applicationEventPublisher.publishEvent(
-			CalendarInvitationEvent.builder()
-				.calendarId(calendarId)
-				.calendarName(calendar.getName())
-				.invitee(invitee)
-				.inviterName(calendar.getOwner().getNickname())
-				.build());
 	}
 
 	@Override
@@ -125,33 +130,25 @@ public class CalendarServiceImpl implements CalendarService {
 
 		if (requestParticipants != null && !requestParticipants.isEmpty()) {
 
-			List<Long> participantMemberIds = requestParticipants.stream()
-				.map(CalendarRequestDto.Participant::getMemberId)
-				.toList();
+			Map<Long, Role> roleMap = requestParticipants.stream()
+				.collect(Collectors.toMap(CalendarRequestDto.Participant::getMemberId,
+					CalendarRequestDto.Participant::getRole));
 
+			List<Long> participantMemberIds = new ArrayList<>(roleMap.keySet());
 			List<Member> members = memberRepository.findAllById(participantMemberIds);
 
-			if (members.size() != participantMemberIds.size()) {
-				throw new ApiException(ResponseStatus.MEMBER_NOT_FOUND);
-			}
-
-			List<Participant> participants = members.stream().map(member -> {
-				Role role = requestParticipants.stream()
-					.filter(p -> p.getMemberId().equals(member.getId()))
-					.map(CalendarRequestDto.Participant::getRole)
-					.findFirst()
-					.orElse(Role.VIEW);
-
-				return Participant.builder()
+			List<Participant> participants = members.stream()
+				.map(member -> Participant.builder()
 					.member(member)
+					.role(roleMap.get(member.getId()))
 					.nickname(member.getNickname())
-					.role(role)
 					.status(ParticipationStatus.PENDING)
-					.build();
-			}).toList();
+					.build())
+				.toList();
 
 			calendar.addParticipants(participants);
 		}
+
 		calendarRepository.save(calendar);
 
 		for (Participant participant : calendar.getParticipants()) {
@@ -167,7 +164,6 @@ public class CalendarServiceImpl implements CalendarService {
 					.inviterName(owner.getNickname())
 					.build());
 		}
-
 		return CalendarResponseDto.CalendarInfo.from(calendar);
 	}
 

--- a/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/calendar/controller/CalendarControllerTest.kt
@@ -60,7 +60,8 @@ class CalendarControllerTest(
         context("정상 초대 요청일 경우") {
             it("200 OK를 반환한다") {
                 val owner = memberRepository.save(createMember(nickname = "test1"))
-                val invitee = memberRepository.save(createMember(email = "test2@gmail.com", nickname = "test2"))
+                val invitee1 = memberRepository.save(createMember(email = "test2@gmail.com", nickname = "test2"))
+                val invitee2 = memberRepository.save(createMember(email = "test3@gmail.com", nickname = "test3"))
                 val calendar = calendarRepository.save(createCalendar())
                 participantRepository.save(
                     createParticipant(
@@ -72,22 +73,33 @@ class CalendarControllerTest(
                     )
                 )
                 val validToken = jwtFixture.createValidToken(owner.id)
-                val body = mapOf("memberId" to invitee.id)
+                val body = mapOf("memberIds" to listOf(invitee1.id, invitee2.id))
                 val response = req.post("/calendars/${calendar.id}/invite", body, validToken)
 
                 res.assertSuccess(response)
 
                 await().atMost(1, TimeUnit.SECONDS).untilAsserted {
-                    val notifications = notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(invitee.id)
-                    notifications.size shouldBe 1
-                    notifications[0].message shouldBe NotificationType.CALENDAR_INVITATION.createMessage(
+                    val notifications1 = notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(invitee1.id)
+                    notifications1.size shouldBe 1
+                    notifications1[0].message shouldBe NotificationType.CALENDAR_INVITATION.createMessage(
                         mapOf(
                             "calendarId" to calendar.id,
                             "calendarName" to calendar.name,
                             "inviterName" to owner.nickname
                         )
                     )
-                    notifications[0].data["calendarId"] shouldBe calendar.id
+                    notifications1[0].data["calendarId"] shouldBe calendar.id
+
+                    val notifications2 = notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(invitee2.id)
+                    notifications2.size shouldBe 1
+                    notifications2[0].message shouldBe NotificationType.CALENDAR_INVITATION.createMessage(
+                        mapOf(
+                            "calendarId" to calendar.id,
+                            "calendarName" to calendar.name,
+                            "inviterName" to owner.nickname
+                        )
+                    )
+                    notifications2[0].data["calendarId"] shouldBe calendar.id
                 }
             }
         }
@@ -97,7 +109,7 @@ class CalendarControllerTest(
                 val owner = memberRepository.save(createMember(nickname = "test1"))
                 val invitee = memberRepository.save(createMember(email = "test2@gmail.com", nickname = "test2"))
                 val validToken = jwtFixture.createValidToken(owner.id)
-                val body = mapOf("memberId" to invitee.id)
+                val body = mapOf("memberIds" to listOf(invitee.id))
                 val response = req.post("/calendars/999/invite", body, validToken)
 
                 res.assertFailure(response, ResponseStatus.CALENDAR_NOT_FOUND)
@@ -119,7 +131,7 @@ class CalendarControllerTest(
                     )
                 )
                 val validToken = jwtFixture.createValidToken(invitee.id)
-                val body = mapOf("memberId" to invitee.id)
+                val body = mapOf("memberIds" to listOf(invitee.id))
                 val response = req.post("/calendars/${calendar.id}/invite", body, validToken)
 
                 res.assertFailure(response, ResponseStatus.MEMBER_NOT_OWNER)
@@ -127,7 +139,7 @@ class CalendarControllerTest(
         }
 
         context("초대할 멤버가 존재하지 않는 경우") {
-            it("404 Not Found를 반환한다") {
+            it("200 OK를 반혼하고 알림을 보내지 않는다") {
                 val owner = memberRepository.save(createMember(nickname = "test1"))
                 val calendar = calendarRepository.save(createCalendar())
                 participantRepository.save(
@@ -140,15 +152,15 @@ class CalendarControllerTest(
                     )
                 )
                 val validToken = jwtFixture.createValidToken(owner.id)
-                val body = mapOf("memberId" to 999)
+                val body = mapOf("memberIds" to listOf(999))
                 val response = req.post("/calendars/${calendar.id}/invite?memberId=${owner.id}", body, validToken)
 
-                res.assertFailure(response, ResponseStatus.MEMBER_NOT_FOUND)
+                res.assertSuccess(response)
             }
         }
 
         context("초대할 멤버가 이미 초대된 경우") {
-            it("409 Conflict를 반환한다") {
+            it("200 OK를 반환하고 알림을 보낸다") {
                 val owner = memberRepository.save(createMember(nickname = "test1"))
                 val invitee = memberRepository.save(createMember(email = "test2@gmail.com", nickname = "test2"))
                 val calendar = calendarRepository.save(createCalendar())
@@ -169,15 +181,27 @@ class CalendarControllerTest(
                         participationStatus = ParticipationStatus.PENDING
                     )
                 )
-                val body = mapOf("memberId" to invitee.id)
+                val body = mapOf("memberIds" to listOf(invitee.id))
                 val response = req.post("/calendars/${calendar.id}/invite", body, validToken)
+                res.assertSuccess(response)
 
-                res.assertFailure(response, ResponseStatus.MEMBER_ALREADY_INVITED)
+                await().atMost(1, TimeUnit.SECONDS).untilAsserted {
+                    val notifications1 = notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(invitee.id)
+                    notifications1.size shouldBe 1
+                    notifications1[0].message shouldBe NotificationType.CALENDAR_INVITATION.createMessage(
+                        mapOf(
+                            "calendarId" to calendar.id,
+                            "calendarName" to calendar.name,
+                            "inviterName" to owner.nickname
+                        )
+                    )
+                    notifications1[0].data["calendarId"] shouldBe calendar.id
+                }
             }
         }
 
         context("초대할 멤버가 이미 참여 중인 경우") {
-            it("409 Conflict를 반환한다") {
+            it("200 OK를 반환하고 알림을 보내지 않는다") {
                 val owner = memberRepository.save(createMember(nickname = "test1"))
                 val invitee = memberRepository.save(createMember(email = "test2@gmail.com", nickname = "test2"))
                 val calendar = calendarRepository.save(createCalendar())
@@ -198,15 +222,20 @@ class CalendarControllerTest(
                         participationStatus = ParticipationStatus.ACCEPTED
                     )
                 )
-                val body = mapOf("memberId" to invitee.id)
+                val body = mapOf("memberIds" to listOf(invitee.id))
                 val response = req.post("/calendars/${calendar.id}/invite", body, validToken)
 
-                res.assertFailure(response, ResponseStatus.MEMBER_ALREADY_PARTICIPANT)
+                res.assertSuccess(response)
+
+                await().atMost(1, TimeUnit.SECONDS).untilAsserted {
+                    val notifications1 = notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(invitee.id)
+                    notifications1.size shouldBe 0
+                }
             }
         }
 
         context("초대할 멤버가 초대를 이미 거부한 경우") {
-            it("200 OK를 반환하고 상태를 PENDING으로 변경한다") {
+            it("200 OK를 반환하고 상태를 PENDING으로 변경하고 알림을 보낸다") {
                 val owner = memberRepository.save(createMember(nickname = "test1"))
                 val invitee = memberRepository.save(createMember(email = "test2@gmail.com", nickname = "test2"))
                 val calendar = calendarRepository.save(createCalendar())
@@ -227,7 +256,7 @@ class CalendarControllerTest(
                         participationStatus = ParticipationStatus.DECLINED
                     )
                 )
-                val body = mapOf("memberId" to invitee.id)
+                val body = mapOf("memberIds" to listOf(invitee.id))
                 val response = req.post("/calendars/${calendar.id}/invite", body, validToken)
 
                 res.assertSuccess(response)
@@ -532,6 +561,7 @@ class CalendarControllerTest(
                 val owner = memberRepository.save(createMember())
                 val token = jwtFixture.createValidToken(owner.id)
 
+
                 val request = mapOf(
                     "title" to "Test Calendar",
                     "participants" to listOf(
@@ -548,8 +578,9 @@ class CalendarControllerTest(
         }
 
         context("참가할 멤버가 존재하지 않는 경우") {
-            it("404 Not Found를 반환한다") {
-                val owner = memberRepository.save(createMember())
+            it("해당 멤버를 제외하고 캘린더를 생성하고 200 OK를 반환한다") {
+                val owner = memberRepository.save(createMember(nickname = "owner"))
+                val invitee = memberRepository.save(createMember())
                 val token = jwtFixture.createValidToken(owner.id)
 
                 val request = mapOf(
@@ -558,12 +589,37 @@ class CalendarControllerTest(
                         mapOf(
                             "memberId" to 999,
                             "role" to "VIEW"
+                        ),
+                        mapOf(
+                            "memberId" to invitee.id,
+                            "role" to "EDIT"
                         )
                     )
                 )
                 val response = req.post("/calendars", request, token)
 
-                res.assertFailure(response, ResponseStatus.MEMBER_NOT_FOUND)
+                res.assertSuccess(response)
+
+                val json = objectMapper.readTree(response.contentAsString)
+                val calendarName = json["data"]["title"].asText()
+                val calendarId = json["data"]["calendarId"].asLong()
+
+                calendarName shouldBe request["title"]
+
+                await().atMost(1, TimeUnit.SECONDS).untilAsserted {
+                    val notification1 = notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(invitee.id)
+                    notification1.size shouldBe 1
+                    notification1[0].message shouldBe NotificationType.CALENDAR_INVITATION.createMessage(
+                        mapOf(
+                            "calendarId" to calendarId,
+                            "calendarName" to calendarName,
+                            "inviterName" to owner.nickname
+                        )
+                    )
+                    notification1[0].data["calendarId"] shouldBe calendarId
+
+                }
+
             }
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #90 

## 🎁 작업 내용
- 초대 API가 여러 사용자를 동시에 초대할 수 있게 개선
- 재초대 로직 수정, 거절했거나 수락하지 않은 경우 다시 초대 알림 전송 or 이미 참여하고 있는 경우는 무시
- 여러 사용자를 초대할 때, 일부 사용자 ID가 존재하지 않아도 나머지 사용자들은 정상적으로 초대되도록 변경
- 위 로직에 맞게 테스트 케이스 수정