### PR TITLE
:hammer: CustomAuthenticationEntryPoint 응답 포맷 수정

### DIFF
--- a/src/main/java/com/example/scheduo/global/config/security/entry/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/scheduo/global/config/security/entry/CustomAuthenticationEntryPoint.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 	private final LoggingService loggingService;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
@@ -37,7 +38,6 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
 		ErrorResponseDto result = ApiResponse.onFailure(exception);
 
-		ObjectMapper objectMapper = new ObjectMapper();
 		response.getWriter().write(objectMapper.writeValueAsString(result));
 	}
 }

--- a/src/main/java/com/example/scheduo/global/config/security/entry/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/scheduo/global/config/security/entry/CustomAuthenticationEntryPoint.java
@@ -1,14 +1,14 @@
 package com.example.scheduo.global.config.security.entry;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import com.example.scheduo.global.logger.service.LoggingService;
+import com.example.scheduo.global.response.ApiResponse;
+import com.example.scheduo.global.response.exception.ErrorResponseDto;
 import com.example.scheduo.global.response.status.ResponseStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -35,15 +35,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
 		loggingService.logError(request, exception.getStatus(), exception.getMessage());
 
-		String message = switch (exception) {
-			case INVALID_TOKEN, NOT_EXIST_TOKEN -> exception.getMessage();
-			default -> ResponseStatus.DEFAULT_TOKEN_ERROR.getMessage();
-		};
-		
-		Map<String, Object> result = new HashMap<>();
-		result.put("code", 401);
-		result.put("success", false);
-		result.put("message", message);
+		ErrorResponseDto result = ApiResponse.onFailure(exception);
 
 		ObjectMapper objectMapper = new ObjectMapper();
 		response.getWriter().write(objectMapper.writeValueAsString(result));

--- a/src/test/kotlin/com/example/scheduo/global/config/JwtAuthenticationTest.kt
+++ b/src/test/kotlin/com/example/scheduo/global/config/JwtAuthenticationTest.kt
@@ -1,18 +1,18 @@
 package com.example.scheduo.global.config
 
-import com.example.scheduo.domain.member.entity.Member
 import com.example.scheduo.domain.member.repository.MemberRepository
 import com.example.scheduo.fixture.JwtFixture
 import com.example.scheduo.fixture.createMember
+import com.example.scheduo.global.response.status.ResponseStatus
+import com.example.scheduo.util.Request
+import com.example.scheduo.util.Response
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.get
 import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
@@ -20,60 +20,46 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @ActiveProfiles("test")
 class JwtAuthenticationTest(
-        @Autowired val mockMvc: MockMvc,
-        @Autowired val objectMapper: ObjectMapper,
-        @Autowired val memberRepository: MemberRepository,
-        @Autowired val jwtFixture: JwtFixture
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val objectMapper: ObjectMapper,
+    @Autowired val memberRepository: MemberRepository,
+    @Autowired val jwtFixture: JwtFixture
 ) : DescribeSpec({
 
-    var testMember: Member? = null
+    lateinit var req: Request
+    lateinit var res: Response
 
     beforeTest {
+        req = Request(mockMvc, objectMapper)
+        res = Response(objectMapper)
+    }
+
+    afterTest {
         memberRepository.deleteAll()
-        testMember = memberRepository.save(createMember(email = "user@example.com", nickname = "홍길동"))
     }
 
     describe("인증이 필요한 API 요청 시") {
         context("유효한 토큰이 Authorization 헤더에 있을 경우") {
             it("200 OK와 정상 응답이 반환된다") {
-                val validToken = jwtFixture.createValidToken(testMember!!.id!!)
-                val response = mockMvc.get("/members/me") {
-                    header("Authorization", "Bearer $validToken")
-                }
-                        .andReturn().response
-
-                response.status shouldBe 200
-                val json = objectMapper.readTree(response.contentAsString)
-                json["success"].asBoolean() shouldBe true
+                val member = memberRepository.save(createMember(email = "test@example.com"))
+                val validToken = jwtFixture.createValidToken(member.id)
+                val response = req.get("/members/me", token = validToken)
+                res.assertSuccess(response)
             }
         }
 
         context("토큰이 없을 경우") {
             it("401 Unauthorized와 에러 메시지가 반환된다") {
-                val response = mockMvc.get("/members/me")
-                        .andReturn().response
-
-                response.status shouldBe 401
-                val json = objectMapper.readTree(response.contentAsString)
-                json["code"].asInt() shouldBe 401
-                json["success"].asBoolean() shouldBe false
-                json["message"].asText() shouldBe "토큰이 없습니다."
+                val response = req.get("/members/me")
+                res.assertFailure(response, ResponseStatus.NOT_EXIST_TOKEN)
             }
         }
 
         context("유효하지 않은 토큰이 Authorization 헤더에 있을 경우") {
             it("401 Unauthorized와 에러 메시지가 반환된다") {
                 val invalidToken = jwtFixture.createInvalidToken()
-                val response = mockMvc.get("/members/me") {
-                    header("Authorization", "Bearer $invalidToken")
-                }
-                        .andReturn().response
-
-                response.status shouldBe 401
-                val json = objectMapper.readTree(response.contentAsString)
-                json["code"].asInt() shouldBe 401
-                json["success"].asBoolean() shouldBe false
-                json["message"].asText() shouldBe "토큰이 유효하지 않습니다."
+                val response = req.get("/members/me", token = invalidToken)
+                res.assertFailure(response, ResponseStatus.INVALID_TOKEN)
             }
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #92

## 🎁 작업 내용
- CustomAutenticationEntryPoint에서 생성하는 응답에 status가 누락되어 있었습니다. 아무래도 CustomAutenticationEntryPoint에서 직접 응답 객체를 생성하다 보니 문제가 발생한거 같아서, ApiResponse를 만들어서 반환하는 형식으로 수정했습니다.
- 테스트 코드도 request, response 유틸 함수들을 사용하게 수정했습니다.

<img width="306" height="155" alt="image" src="https://github.com/user-attachments/assets/9c3c3159-5988-44a4-a9de-9e2598dd6ab7" />
