### PR TITLE
일정 수정 API 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
+++ b/src/main/java/com/example/scheduo/domain/calendar/entity/Calendar.java
@@ -130,4 +130,10 @@ public class Calendar extends BaseEntity {
 			.orElseThrow(() -> new ApiException(ResponseStatus.PARTICIPANT_NOT_FOUND))
 			.isAccepted();
 	}
+
+	public boolean canEdit(Long memberId) {
+		return this.findParticipant(memberId)
+			.orElseThrow(() -> new ApiException(ResponseStatus.PARTICIPANT_NOT_FOUND))
+			.getRole() == Role.EDIT || this.isOwner(memberId);
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.example.scheduo.domain.schedule.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,6 +67,19 @@ public class ScheduleController {
 	) {
 		ScheduleResponseDto.ScheduleInfo result = scheduleService.getScheduleInfo(member, calendarId, scheduleId);
 		return ApiResponse.onSuccess(result);
+	}
+
+	@PatchMapping("/calendars/{calendarId}/schedules/{scheduleId}")
+	@Operation(summary = "일정 수정", description = "해당 일정의 정보를 수정합니다.")
+	public ApiResponse<?> updateSchedule(
+		@RequestMember Member member,
+		@PathVariable("calendarId") Long calendarId,
+		@PathVariable("scheduleId") Long scheduleId,
+		@RequestParam("date") String date,
+		@Valid @RequestBody ScheduleRequestDto.Update request
+	) {
+		scheduleService.updateSchedule(request, member, calendarId, scheduleId, date);
+		return ApiResponse.onSuccess();
 	}
 
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleRequestDto.java
@@ -37,4 +37,34 @@ public class ScheduleRequestDto {
 		@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "날짜 형식은 yyyy-mm-dd이어야 합니다.")
 		private String recurrenceEndDate; // 반복 종료 날짜 (yyyy-mm-dd)
 	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Update {
+		private String title; // 일정 제목
+		private boolean allDay; // 종일 일정 여부
+		@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "날짜 형식은 yyyy-mm-dd이어야 합니다.")
+		private String startDate; // 시작 날짜 (yyyy-mm-dd)
+		@Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "날짜 형식은 yyyy-mm-dd이어야 합니다.")
+		private String endDate; // 종료 날짜 (yyyy-mm-dd)
+		@Pattern(regexp = "\\d{2}:\\d{2}", message = "시간 형식은 hh:mm이어야 합니다.")
+		private String startTime; // 시작 시간 (hh:mm)
+		@Pattern(regexp = "\\d{2}:\\d{2}", message = "시간 형식은 hh:mm이어야 합니다.")
+		private String endTime; // 종료 시간 (hh:mm)
+		private String location; // 장소
+		private String category; // 일정 카테고리
+		private String memo; // 메모
+		private NotificationTime notificationTime; // 알림 시간 (예: THIRTY_MINUTES_BEFORE)
+		private Recurrence recurrence; // 반복 일정 정보
+		private Scope scope;
+	}
+
+	@Getter
+	public enum Scope {
+		ALL, // 모든 일정
+		ONLY_THIS, // 현재 일정만
+		THIS_AND_FUTURE // 현재 일정과 이후 일정
+	}
+
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Exception.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Exception.java
@@ -1,6 +1,6 @@
 package com.example.scheduo.domain.schedule.entity;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
@@ -35,5 +35,9 @@ public class Exception {
 	@JoinColumn(name = "recurrenceId")
 	private Recurrence recurrence;
 
-	private Date exceptionDate;
+	private LocalDate exceptionDate;
+
+	public void setRecurrence(Recurrence recurrence) {
+		this.recurrence = recurrence;
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Exception.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Exception.java
@@ -36,8 +36,4 @@ public class Exception {
 	private Recurrence recurrence;
 
 	private LocalDate exceptionDate;
-
-	public void setRecurrence(Recurrence recurrence) {
-		this.recurrence = recurrence;
-	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Recurrence.java
@@ -81,7 +81,6 @@ public class Recurrence {
 			.exceptionDate(date)
 			.build();
 		this.exceptions.add(exception);
-		exception.setRecurrence(this);
 	}
 
 	public void changeRecurrenceEndDate(String recurrenceEndDate) {

--- a/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/entity/Schedule.java
@@ -12,7 +12,6 @@ import com.example.scheduo.domain.calendar.entity.Calendar;
 import com.example.scheduo.domain.common.BaseEntity;
 import com.example.scheduo.domain.member.entity.Member;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -146,4 +145,34 @@ public class Schedule extends BaseEntity {
 				.build())
 			.toList();
 	}
+
+	public void update(
+		String title,
+		boolean isAllDay,
+		String startDate,
+		String endDate,
+		String startTime,
+		String endTime,
+		String location,
+		String memo,
+		NotificationTime notificationTime,
+		String recurrenceRule,
+		String recurrenceEndDate,
+		Category category
+	) {
+		this.title = title;
+		this.isAllDay = isAllDay;
+		this.startDate = LocalDate.parse(startDate);
+		this.endDate = LocalDate.parse(endDate);
+		this.startTime = LocalTime.parse(isAllDay ? "00:00" : startTime);
+		this.endTime = LocalTime.parse(isAllDay ? "23:59" : endTime);
+		this.location = location;
+		this.memo = memo;
+		this.notificationTime = notificationTime;
+		this.category = category;
+		if (recurrenceRule != null && recurrenceEndDate != null) {
+			this.recurrence.updateRecurrence(recurrenceRule, recurrenceEndDate);
+		}
+	}
+
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
@@ -12,4 +12,7 @@ public interface ScheduleService {
 	ScheduleResponseDto.SchedulesOnDate getSchedulesOnDate(Member member, Long calendarId, String date);
 
 	ScheduleResponseDto.ScheduleInfo getScheduleInfo(Member member, Long calendarId, Long scheduleId);
+
+	void updateSchedule(ScheduleRequestDto.Update request, Member member, Long calendarId, Long scheduleId,
+		String date);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,6 @@ jwt:
 app:
   oauth2:
     authorized-redirect-uris: http://localhost:3000, https://scheduo.store
+
+springdoc:
+  use-fqn: true

--- a/src/test/kotlin/com/example/scheduo/domain/schedule/controller/UpdateScheduleTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/schedule/controller/UpdateScheduleTest.kt
@@ -1,0 +1,414 @@
+package com.example.scheduo.domain.schedule.controller
+
+import com.example.scheduo.domain.calendar.entity.Calendar
+import com.example.scheduo.domain.calendar.entity.ParticipationStatus
+import com.example.scheduo.domain.calendar.entity.Role
+import com.example.scheduo.domain.calendar.repository.CalendarRepository
+import com.example.scheduo.domain.member.entity.Member
+import com.example.scheduo.domain.member.repository.MemberRepository
+import com.example.scheduo.domain.schedule.entity.Schedule
+import com.example.scheduo.domain.schedule.repository.CategoryRepository
+import com.example.scheduo.domain.schedule.repository.RecurrenceRepository
+import com.example.scheduo.domain.schedule.repository.ScheduleRepository
+import com.example.scheduo.fixture.*
+import com.example.scheduo.global.response.status.ResponseStatus
+import com.example.scheduo.util.Request
+import com.example.scheduo.util.Response
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.DescribeSpec
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDate
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UpdateScheduleTest(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val objectMapper: ObjectMapper,
+    @Autowired val memberRepository: MemberRepository,
+    @Autowired val calendarRepository: CalendarRepository,
+    @Autowired val categoryRepository: CategoryRepository,
+    @Autowired val scheduleRepository: ScheduleRepository,
+    @Autowired val recurrenceRepository: RecurrenceRepository,
+    @Autowired val jwtFixture: JwtFixture,
+    @Autowired val tx: TransactionTemplate,
+) : DescribeSpec({
+    lateinit var req: Request
+    lateinit var res: Response
+    lateinit var member: Member
+    lateinit var calendar: Calendar
+    lateinit var singleSchedule: Schedule
+    lateinit var recurrenceSchedule: Schedule
+
+    val date = "2025-08-12"
+
+    beforeSpec {
+        scheduleRepository.deleteAll()
+        recurrenceRepository.deleteAll()
+        categoryRepository.deleteAll()
+        calendarRepository.deleteAll()
+        memberRepository.deleteAll()
+
+        req = Request(mockMvc, objectMapper)
+        res = Response(objectMapper)
+
+        member = memberRepository.save(createMember(nickname = "test"))
+        calendar = createCalendar()
+        val participant = createParticipant(
+            member = member,
+            calendar = calendar,
+            role = Role.EDIT,
+            participationStatus = ParticipationStatus.ACCEPTED
+        )
+        calendar.addParticipant(participant)
+        calendarRepository.save(calendar)
+    }
+
+
+    beforeTest {
+        singleSchedule = createSchedule(
+            title = "단일 일정",
+            startDate = "2025-08-01",
+            endDate = "2025-08-01",
+            member = member,
+            calendar = calendar,
+            category = categoryRepository.save(createCategory())
+        )
+
+        val recurrence = createRecurrence(
+            frequency = "WEEKLY",
+            recurrenceEndDate = "2025-12-31"
+        )
+
+        recurrenceRepository.save(recurrence)
+
+        recurrenceSchedule = createSchedule(
+            title = "반복 일정",
+            startDate = "2025-08-01",
+            endDate = "2025-08-01",
+            member = member,
+            calendar = calendar,
+            category = categoryRepository.save(createCategory()),
+            recurrence = recurrence
+        )
+
+        scheduleRepository.saveAll(listOf(singleSchedule, recurrenceSchedule))
+    }
+
+    afterTest {
+        scheduleRepository.deleteAll()
+        recurrenceRepository.deleteAll()
+    }
+
+    afterSpec {
+        categoryRepository.deleteAll()
+        calendarRepository.deleteAll()
+        memberRepository.deleteAll()
+    }
+
+    describe("PATCH /calendars/{calendarId}/schedules/{scheduleId}") {
+        context("schedule이 존재하지 않는 경우") {
+            it("404 Not Found를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val nonExistentScheduleId = 999L
+                val body = mapOf(
+                    "title" to "수정된 일정",
+                    "startDate" to "2025-08-01",
+                    "endDate" to "2025-08-01",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 A",
+                    "memo" to "수정된 메모"
+                )
+
+                val response =
+                    req.patch(
+                        "/calendars/${calendar.id}/schedules/$nonExistentScheduleId?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertFailure(response, ResponseStatus.SCHEDULE_NOT_FOUND)
+            }
+        }
+
+        context("calendar가 존재하지 않는 경우") {
+            it("404 Not Found를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val nonExistentCalendarId = 999L
+                val body = mapOf(
+                    "title" to "수정된 일정",
+                    "startDate" to "2025-08-01",
+                    "endDate" to "2025-08-01",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 A",
+                    "memo" to "수정된 메모"
+                )
+
+                val response =
+                    req.patch(
+                        "/calendars/${nonExistentCalendarId}/schedules/${singleSchedule.id} ?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertFailure(response, ResponseStatus.CALENDAR_NOT_FOUND)
+
+            }
+        }
+
+        context("일정이 캘린더에 속하지 않는 경우") {
+            it("404 Not Found를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val anotherCalendar = calendarRepository.save(createCalendar())
+                val body = mapOf(
+                    "title" to "수정된 일정",
+                    "startDate" to "2025-08-01",
+                    "endDate" to "2025-08-01",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 A",
+                    "memo" to "수정된 메모"
+                )
+                val response =
+                    req.patch(
+                        "/calendars/${anotherCalendar.id}/schedules/${singleSchedule.id}?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertFailure(response, ResponseStatus.SCHEDULE_NOT_FOUND)
+            }
+        }
+
+
+        context("수정할 권한이 없는 경우") {
+            it("403 Forbidden을 반환한다") {
+                val memberWithoutPermission = memberRepository.save(createMember(nickname = "no_permission"))
+                val participant = createParticipant(
+                    member = memberWithoutPermission,
+                    calendar = calendar,
+                    role = Role.VIEW,
+                    participationStatus = ParticipationStatus.ACCEPTED
+                )
+                calendar.addParticipant(participant)
+                calendarRepository.save(calendar)
+
+                val token = jwtFixture.createValidToken(memberWithoutPermission.id)
+                val body = mapOf(
+                    "title" to "수정된 일정",
+                    "startDate" to "2025-08-01",
+                    "endDate" to "2025-08-01",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 A",
+                    "memo" to "수정된 메모",
+                    "category" to singleSchedule.category.name
+                )
+                val response =
+                    req.patch(
+                        "/calendars/${calendar.id}/schedules/${singleSchedule.id}?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertFailure(response, ResponseStatus.PARTICIPANT_PERMISSION_LEAK)
+            }
+        }
+
+        context("카테고리가 존재하지 않는 경우") {
+            it("404 Not Found를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                    "title" to "수정된 일정",
+                    "startDate" to "2025-08-01",
+                    "endDate" to "2025-08-01",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 A",
+                    "memo" to "수정된 메모",
+                    "category" to "존재하지 않는 카테고리"
+                )
+
+                val response =
+                    req.patch(
+                        "/calendars/${calendar.id}/schedules/${singleSchedule.id}?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertFailure(response, ResponseStatus.CATEGORY_NOT_FOUND)
+
+            }
+        }
+
+        context("단일 일정을 수정하는 경우") {
+            it("200 OK와 수정된 일정 정보를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                    "title" to "수정된 단일 일정",
+                    "startDate" to "2025-08-02",
+                    "endDate" to "2025-08-02",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 A",
+                    "memo" to "수정된 메모",
+                    "category" to singleSchedule.category.name,
+                    "recurrence" to null,
+                )
+
+                val response =
+                    req.patch(
+                        "/calendars/${calendar.id}/schedules/${singleSchedule.id}?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertSuccess(response)
+                tx.execute {
+                    val updatedSchedule = scheduleRepository.findById(singleSchedule.id)
+                    updatedSchedule.ifPresent { schedule ->
+                        assert(schedule.title == "수정된 단일 일정")
+                        assert(schedule.startDate.toString() == "2025-08-02")
+                        assert(schedule.endDate.toString() == "2025-08-02")
+                        assert(schedule.startTime.toString() == "10:00")
+                        assert(schedule.endTime.toString() == "11:00")
+                        assert(!schedule.isAllDay)
+                        assert(schedule.location == "회의실 A")
+                        assert(schedule.memo == "수정된 메모")
+                    }
+                }
+            }
+        }
+
+        context("반복 일정 전체를 수정하는 경우") {
+            it("200 OK와 수정된 반복 일정 정보를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                    "title" to "수정된 반복 일정",
+                    "startDate" to "2025-08-02",
+                    "endDate" to "2025-08-02",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 B",
+                    "memo" to "수정된 메모",
+                    "category" to recurrenceSchedule.category.name,
+                    "recurrence" to mapOf(
+                        "frequency" to "WEEKLY",
+                        "recurrenceEndDate" to "2025-10-01"
+                    ),
+                    "scope" to "ALL"
+                )
+                val response =
+                    req.patch(
+                        "/calendars/${calendar.id}/schedules/${recurrenceSchedule.id}?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertSuccess(response)
+
+                tx.execute {
+                    val updatedSchedule = scheduleRepository.findById(recurrenceSchedule.id)
+                    updatedSchedule.ifPresent { schedule ->
+                        assert(schedule.title == "수정된 반복 일정")
+                        assert(schedule.startDate.toString() == "2025-08-02")
+                        assert(schedule.endDate.toString() == "2025-08-02")
+                        assert(schedule.startTime.toString() == "10:00")
+                        assert(schedule.endTime.toString() == "11:00")
+                        assert(!schedule.isAllDay)
+                        assert(schedule.location == "회의실 B")
+                        assert(schedule.memo == "수정된 메모")
+                        assert(schedule.recurrence.frequency == "WEEKLY")
+                        assert(schedule.recurrence.recurrenceEndDate.toString() == "2025-10-01")
+                        assert(schedule.recurrence.exceptions.isEmpty())
+                    }
+                }
+            }
+        }
+
+        context("반복 일정 중 하나만 수정하는 경우") {
+            it("200 OK와 수정된 반복 일정 정보를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                    "title" to "수정된 반복 일정 일부",
+                    "startDate" to "2025-08-02",
+                    "endDate" to "2025-08-02",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 C",
+                    "memo" to "수정된 메모 일부",
+                    "category" to recurrenceSchedule.category.name,
+                    "recurrence" to mapOf(
+                        "frequency" to "WEEKLY",
+                        "recurrenceEndDate" to "2025-12-31"
+                    ),
+                    "scope" to "ONLY_THIS"
+                )
+
+                val response =
+                    req.patch(
+                        "/calendars/${calendar.id}/schedules/${recurrenceSchedule.id}?date=$date",
+                        body = body,
+                        token = token
+                    )
+
+                res.assertSuccess(response)
+
+                tx.execute {
+                    val updatedSchedule = scheduleRepository.findById(recurrenceSchedule.id)
+                    updatedSchedule.ifPresent {
+                        assert(it.recurrence.frequency == recurrenceSchedule.recurrence.frequency)
+                        assert(it.recurrence.exceptions.any { it -> it.exceptionDate == LocalDate.parse(date) })
+                        assert(it.recurrence.exceptions.size == 1)
+                    }
+                }
+            }
+        }
+
+        context("반복 일정에서 이후 일정들을 모두 수정하는 경우") {
+            it("200 OK와 수정된 반복 일정 정보를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                    "title" to "수정된 반복 일정 이후",
+                    "startDate" to "2025-08-02",
+                    "endDate" to "2025-08-02",
+                    "startTime" to "10:00",
+                    "endTime" to "11:00",
+                    "isAllDay" to false,
+                    "location" to "회의실 D",
+                    "memo" to "수정된 메모 이후",
+                    "category" to recurrenceSchedule.category.name,
+                    "recurrence" to mapOf(
+                        "frequency" to "WEEKLY",
+                        "recurrenceEndDate" to "2025-12-31"
+                    ),
+                    "scope" to "THIS_AND_FUTURE"
+                )
+
+                val response =
+                    req.patch(
+                        "/calendars/${calendar.id}/schedules/${recurrenceSchedule.id}?date=$date",
+                        body = body,
+                        token = token
+                    )
+                res.assertSuccess(response)
+
+                tx.execute {
+                    val updatedSchedule = scheduleRepository.findById(recurrenceSchedule.id)
+                    updatedSchedule.ifPresent {
+                        assert(it.recurrence.recurrenceEndDate == LocalDate.parse(body["startDate"] as String))
+                        assert(it.recurrence.exceptions.isEmpty())
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #98

## 🎁 작업 내용
1. 단일 일정은 그대로 수정
2. 반복 일정의 경우
  - ALL이면 그냥 수정
  - ONLY_THIS이면 반복 일정에 예외 날짜를 추가하고, 새로운 단일 일정 생성
  - THIS_AND_FUTURE는 기존 반복 일정을 2개로 나눔. 예를 들어서 1월부터 12월까지 반복인 일정이 있을때, 8월달에 있는 일정 이후로 모두 수정하면, 1~8, 8~12로 일정을 나눠서 저장