### PR TITLE
[Fix] 특정 날짜 일정 조회 수정

### DIFF
--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -49,6 +49,7 @@ public class ScheduleController {
 	}
 
 	@Operation(summary = "캘린더 별 특정 날짜의 일정 조회", description = "해당 캘린더의 특정 날짜의 모든 일정을 조회합니다.")
+	@Operation(summary = "일정 날짜별 조회", description = "해당 캘린더의 특정 날짜에 일정을 조회합니다.")
 	@GetMapping("/calendars/{calendarId}/schedules")
 	public ApiResponse<ScheduleResponseDto.SchedulesOnDate> getScheduleOnDate(
 		@RequestMember Member member,

--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -49,7 +49,6 @@ public class ScheduleController {
 	}
 
 	@Operation(summary = "캘린더 별 특정 날짜의 일정 조회", description = "해당 캘린더의 특정 날짜의 모든 일정을 조회합니다.")
-	@Operation(summary = "일정 날짜별 조회", description = "해당 캘린더의 특정 날짜에 일정을 조회합니다.")
 	@GetMapping("/calendars/{calendarId}/schedules")
 	public ApiResponse<ScheduleResponseDto.SchedulesOnDate> getScheduleOnDate(
 		@RequestMember Member member,
@@ -93,7 +92,8 @@ public class ScheduleController {
 		@RequestParam("startDate") String startDate,
 		@RequestParam("endDate") String endDate
 	) {
-		ScheduleResponseDto.SchedulesInRange res = scheduleService.getSchedulesInRange(member, calendarId, startDate, endDate);
+		ScheduleResponseDto.SchedulesInRange res = scheduleService.getSchedulesInRange(member, calendarId, startDate,
+			endDate);
 		return ApiResponse.onSuccess(res);
 	}
 

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.scheduo.domain.schedule.dto;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -68,17 +69,18 @@ public class ScheduleResponseDto {
 	private static class ScheduleOnDate {
 		private Long id;
 		private String title;
-		private LocalTime startTime;
-		private LocalTime endTime;
+		private String startTime;
+		private String endTime;
 		private boolean isAllDay;
 		private Category category;
 
 		public static ScheduleOnDate from(Schedule schedule) {
+			DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
 			return new ScheduleOnDate(
 				schedule.getId(),
 				schedule.getTitle(),
-				schedule.getStartTime(),
-				schedule.getEndTime(),
+				schedule.getStartTime().format(formatter),
+				schedule.getEndTime().format(formatter),
 				schedule.isAllDay(),
 				Category.from(schedule.getCategory().getName(), schedule.getCategory().getColor())
 			);

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -181,8 +181,8 @@ public class ScheduleServiceImpl implements ScheduleService {
 			if (!s1.getStartTime().equals(s2.getStartTime()))
 				return s1.getStartTime().compareTo(s2.getStartTime());
 
-			// 3. 동점 처리 로직(일정 생성 기준 우선 정렬)
-			return s1.getCreatedAt().compareTo(s2.getCreatedAt());
+			// Title 기준으로 정렬
+			return s1.getTitle().compareTo(s2.getTitle());
 		});
 
 		return ScheduleResponseDto.SchedulesOnDate.from(filteredSchedules);

--- a/src/test/kotlin/com/example/scheduo/domain/schedule/controller/ScheduleControllerTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/schedule/controller/ScheduleControllerTest.kt
@@ -504,8 +504,8 @@ class ScheduleControllerTest(
                 schedulesNode.size() shouldBe 2
 
                 val scheduleDetails = schedulesNode.map { it.path("title").asText() to it.path("startTime").asText() }
-                scheduleDetails.contains("아침 회의" to "09:00:00") shouldBe true
-                scheduleDetails.contains("오후 미팅" to "14:00:00") shouldBe true
+                scheduleDetails.contains("아침 회의" to "09:00") shouldBe true
+                scheduleDetails.contains("오후 미팅" to "14:00") shouldBe true
             }
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #105

## 🎁 작업 내용
- API 응답에서 LocalTime을 String으로 수정
- 일정 정렬에서 creatdAt으로 정렬하는 부분을 title로 정렬하도록 수정. 반복 일정들은 createdAt 값이 없기 때문