### PR TITLE
[Feat] 일정 공유 api 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -96,4 +96,14 @@ public class ScheduleController {
 		return ApiResponse.onSuccess(res);
 	}
 
+	@Operation(summary = "일정 공유", description = "캘린더 간 일정 공유를 합니다.")
+	@PostMapping("/calendars/{calendarId}/schedules/share")
+	public ApiResponse<?> shareSchedule(
+		@RequestMember Member member,
+		@PathVariable("calendarId") Long calendarId,
+		@RequestBody ScheduleRequestDto.Share req
+	) {
+		scheduleService.shareSchedule(member, calendarId, req.getTargetCalendarId(), req.getSchedules());
+		return ApiResponse.onSuccess();
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleRequestDto.java
@@ -1,5 +1,8 @@
 package com.example.scheduo.domain.schedule.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import com.example.scheduo.domain.schedule.entity.NotificationTime;
 
 import jakarta.validation.constraints.Pattern;
@@ -67,4 +70,19 @@ public class ScheduleRequestDto {
 		THIS_AND_FUTURE // 현재 일정과 이후 일정
 	}
 
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Share {
+		private Long targetCalendarId;
+		private List<ScheduleTime> schedules;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class ScheduleTime {
+		private LocalDateTime startDateTime;
+		private LocalDateTime endDateTime;
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -365,10 +365,8 @@ public class ScheduleServiceImpl implements ScheduleService {
 			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
 
 		// 멤버 권한 확인(fromCalendar - participant이면 ok, toCalendar - participant 이면서 edit 이상)
-		if(!fromCalendar.validateParticipant(member.getId()))
-			throw new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION);
-		if(!toCalendar.validateParticipant(member.getId()))
-			throw new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION);
+		fromCalendar.validateParticipant(member.getId());
+		toCalendar.validateParticipant(member.getId());
 
 		if(!toCalendar.canEdit(member.getId()))
 			throw new ApiException(ResponseStatus.PARTICIPANT_PERMISSION_LEAK);
@@ -379,6 +377,9 @@ public class ScheduleServiceImpl implements ScheduleService {
 
 		// toCalendar에 새로운 일정 생성
 		List<Schedule> schedules = scheduleTimes.stream().map(st -> {
+			if(st.getStartDateTime().isAfter(st.getEndDateTime()))
+				throw new ApiException(ResponseStatus.INVALID_SCHEDULE_RANGE);
+
 			LocalDate startDate = st.getStartDateTime().toLocalDate();
 			LocalDate endDate = st.getEndDateTime().toLocalDate();
 

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.scheduo.domain.schedule.service.Impl;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.scheduo.domain.calendar.entity.Calendar;
+import com.example.scheduo.domain.calendar.entity.Participant;
 import com.example.scheduo.domain.calendar.repository.CalendarRepository;
 import com.example.scheduo.domain.member.entity.Member;
 import com.example.scheduo.domain.schedule.dto.ScheduleRequestDto;
@@ -349,5 +352,65 @@ public class ScheduleServiceImpl implements ScheduleService {
 		});
 
 		return ScheduleResponseDto.SchedulesInRange.from(filteredSchedules);
+	}
+
+	@Override
+	@Transactional
+	public void shareSchedule(Member member, Long calendarId, Long targetCalendarId,
+		List<ScheduleRequestDto.ScheduleTime> scheduleTimes) {
+		// 캘린더 존재여부 확인(fromCalendar, toCalendar)
+		Calendar fromCalendar = calendarRepository.findByIdWithParticipants(calendarId)
+			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
+		Calendar toCalendar = calendarRepository.findByIdWithParticipants(targetCalendarId)
+			.orElseThrow(() -> new ApiException(ResponseStatus.CALENDAR_NOT_FOUND));
+
+		// 멤버 권한 확인(fromCalendar - participant이면 ok, toCalendar - participant 이면서 edit 이상)
+		if(!fromCalendar.validateParticipant(member.getId()))
+			throw new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION);
+		if(!toCalendar.validateParticipant(member.getId()))
+			throw new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION);
+
+		if(!toCalendar.canEdit(member.getId()))
+			throw new ApiException(ResponseStatus.PARTICIPANT_PERMISSION_LEAK);
+
+		String nicknameByToCalendar = toCalendar.findParticipant(member.getId())
+			.map(Participant::getNickname)
+			.orElseThrow(() -> new ApiException(ResponseStatus.INVALID_CALENDAR_PARTICIPATION));
+
+		// toCalendar에 새로운 일정 생성
+		List<Schedule> schedules = scheduleTimes.stream().map(st -> {
+			LocalDate startDate = st.getStartDateTime().toLocalDate();
+			LocalDate endDate = st.getEndDateTime().toLocalDate();
+
+			LocalTime startTime = st.getStartDateTime().toLocalTime();
+			LocalTime endTime = st.getEndDateTime().toLocalTime();
+
+			DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+			DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+			// isAllDay 계산 로직
+			boolean isAllDay = LocalTime.MIDNIGHT.equals(startTime)
+				&& LocalTime.of(23,59,59).equals(endTime);
+
+			Category category = categoryRepository.findByName("default").orElseThrow(() -> new ApiException(ResponseStatus.CATEGORY_NOT_FOUND));
+
+			return Schedule.create(
+				nicknameByToCalendar,
+				isAllDay,
+				startDate.format(DATE_FMT),
+				endDate.format(DATE_FMT),
+				startTime.format(TIME_FMT),
+				endTime.format(TIME_FMT),
+				null,
+				null,
+				null,
+				category,
+				member,
+				toCalendar,
+				null
+			);
+		}).toList();
+
+		schedules.forEach(s -> scheduleRepository.save(s));
 	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
@@ -1,5 +1,7 @@
 package com.example.scheduo.domain.schedule.service;
 
+import java.util.List;
+
 import com.example.scheduo.domain.member.entity.Member;
 import com.example.scheduo.domain.schedule.dto.ScheduleRequestDto;
 import com.example.scheduo.domain.schedule.dto.ScheduleResponseDto;
@@ -17,4 +19,6 @@ public interface ScheduleService {
 		String date);
 
 	ScheduleResponseDto.SchedulesInRange getSchedulesInRange(Member member, Long calendarId, String startDate, String endDate);
+
+	void shareSchedule(Member member, Long calendarId, Long targetCalendarId, List<ScheduleRequestDto.ScheduleTime> schedules);
 }

--- a/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
+++ b/src/main/java/com/example/scheduo/global/response/status/ResponseStatus.java
@@ -62,6 +62,7 @@ public enum ResponseStatus {
 
 	// 일정 관련 에러 응답
 	SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_0001", "일정을 찾을 수 없습니다."),
+	INVALID_SCHEDULE_RANGE(HttpStatus.NOT_FOUND, "SCHEDULE_0002", "일정 생성에 사용되는 기간이 부적절합니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/kotlin/com/example/scheduo/domain/schedule/controller/ShareScheduleTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/schedule/controller/ShareScheduleTest.kt
@@ -1,0 +1,289 @@
+package com.example.scheduo.domain.schedule.controller
+
+import com.example.scheduo.domain.calendar.entity.Calendar
+import com.example.scheduo.domain.calendar.entity.ParticipationStatus
+import com.example.scheduo.domain.calendar.entity.Role
+import com.example.scheduo.domain.calendar.repository.CalendarRepository
+import com.example.scheduo.domain.member.entity.Member
+import com.example.scheduo.domain.member.repository.MemberRepository
+import com.example.scheduo.domain.schedule.entity.Schedule
+import com.example.scheduo.domain.schedule.repository.CategoryRepository
+import com.example.scheduo.domain.schedule.repository.RecurrenceRepository
+import com.example.scheduo.domain.schedule.repository.ScheduleRepository
+import com.example.scheduo.fixture.*
+import com.example.scheduo.global.response.status.ResponseStatus
+import com.example.scheduo.util.Request
+import com.example.scheduo.util.Response
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.DescribeSpec
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.transaction.support.TransactionTemplate
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ShareScheduleTest(
+        @Autowired val mockMvc: MockMvc,
+        @Autowired val objectMapper: ObjectMapper,
+        @Autowired val memberRepository: MemberRepository,
+        @Autowired val calendarRepository: CalendarRepository,
+        @Autowired val categoryRepository: CategoryRepository,
+        @Autowired val scheduleRepository: ScheduleRepository,
+        @Autowired val recurrenceRepository: RecurrenceRepository,
+        @Autowired val jwtFixture: JwtFixture,
+        @Autowired val tx: TransactionTemplate,
+) : DescribeSpec({
+
+    lateinit var req: Request
+    lateinit var res: Response
+    lateinit var member: Member
+    lateinit var fromCalendar: Calendar
+    lateinit var toCalendar: Calendar
+
+    beforeSpec {
+        scheduleRepository.deleteAll()
+        recurrenceRepository.deleteAll()
+        categoryRepository.deleteAll()
+        calendarRepository.deleteAll()
+        memberRepository.deleteAll()
+
+        req = Request(mockMvc, objectMapper)
+        res = Response(objectMapper)
+
+        // 멤버
+        member = memberRepository.save(createMember(nickname = "share_tester"))
+
+        // 기본 카테고리(default) - 서비스에서 조회하므로 반드시 준비
+        categoryRepository.save(createCategory(name = "default"))
+
+        // from 캘린더
+        fromCalendar = createCalendar(name = "from")
+        val fromParticipant = createParticipant(
+                member = member,
+                calendar = fromCalendar,
+                role = Role.VIEW, // 조회 권한이면 충분 (요구사항: from은 participant면 ok)
+                participationStatus = ParticipationStatus.ACCEPTED
+        )
+        fromCalendar.addParticipant(fromParticipant)
+        calendarRepository.save(fromCalendar)
+
+        // to 캘린더
+        toCalendar = createCalendar(name = "to")
+        val toParticipant = createParticipant(
+                member = member,
+                calendar = toCalendar,
+                role = Role.EDIT, // 요구사항: participant 이면서 edit 이상
+                participationStatus = ParticipationStatus.ACCEPTED,
+                nickname = "to-nickname" // title로 복사되어야 함
+        )
+        toCalendar.addParticipant(toParticipant)
+        calendarRepository.save(toCalendar)
+    }
+
+    afterSpec {
+        scheduleRepository.deleteAll()
+        recurrenceRepository.deleteAll()
+        categoryRepository.deleteAll()
+        calendarRepository.deleteAll()
+        memberRepository.deleteAll()
+    }
+
+    describe("POST /calendars/{calendarId}/schedules/share") {
+
+        context("정상 요청 - 4개의 일정 공유") {
+            it("200 OK와 함께 target 캘린더에 4개의 일정이 생성된다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                        "targetCalendarId" to toCalendar.id,
+                        "schedules" to listOf(
+                                mapOf("startDateTime" to "2025-07-01T10:00:00", "endDateTime" to "2025-07-01T11:00:00"),
+                                mapOf("startDateTime" to "2025-07-08T10:00:00", "endDateTime" to "2025-07-08T11:00:00"),
+                                mapOf("startDateTime" to "2025-07-15T10:00:00", "endDateTime" to "2025-07-15T11:00:00"),
+                                mapOf("startDateTime" to "2025-07-22T10:00:00", "endDateTime" to "2025-07-22T11:00:00"),
+                        )
+                )
+
+                val response = req.post(
+                        "/calendars/${fromCalendar.id}/schedules/share",
+                        body = body,
+                        token = token
+                )
+                res.assertSuccess(response)
+
+                tx.execute {
+                    val saved = scheduleRepository.findAll()
+                            .filter { it.calendar.id == toCalendar.id }
+                    assert(saved.size == 4)
+
+                    // 공통 필드 검증
+                    saved.forEach { s: Schedule ->
+                        // title = target 캘린더의 닉네임
+                        assert(s.title == "to-nickname")
+
+                        // category/location/memo = default
+                        assert(s.category.name == "default")
+
+                        // recurrence = null
+                        assert(s.recurrence == null)
+
+                        // allDay = 서버 계산 (10:00~11:00이므로 false)
+                        assert(!s.isAllDay)
+
+                        // 날짜/시간 형식 검증 (서비스가 문자열로 저장하더라도 DB에서 타입 변환되어 들어가있을 수 있으므로 도메인 필드 타입에 맞춰 확인)
+                        assert(s.startTime.toString().startsWith("10:00"))
+                        assert(s.endTime.toString().startsWith("11:00"))
+                    }
+                }
+            }
+        }
+
+        context("권한 부족 - toCalendar 편집 권한 없음") {
+            it("403 Forbidden(PARTICIPANT_PERMISSION_LEAK)을 반환한다") {
+                // toCalendar에서 권한을 VIEW로 낮추기
+                tx.execute {
+                    val cal = calendarRepository.findByIdWithParticipants(toCalendar.id!!).get()
+                    val participant = cal.participants.first { it.member.id == member.id }
+                    participant.updateRole(Role.VIEW) // fixture의 도메인 메서드가 없다면 직접 set
+                    calendarRepository.save(cal)
+                }
+
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                        "targetCalendarId" to toCalendar.id,
+                        "schedules" to listOf(
+                                mapOf("startDateTime" to "2025-07-01T10:00:00", "endDateTime" to "2025-07-01T11:00:00")
+                        )
+                )
+
+                val response = req.post(
+                        "/calendars/${fromCalendar.id}/schedules/share",
+                        body = body,
+                        token = token
+                )
+
+                res.assertFailure(response, ResponseStatus.PARTICIPANT_PERMISSION_LEAK)
+            }
+        }
+
+        context("캘린더가 존재하지 않는 경우(fromCalendar)") {
+            it("404 Not Found(CALENDAR_NOT_FOUND)를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val nonExistentCalendarId = 999_999L
+                val body = mapOf(
+                        "targetCalendarId" to toCalendar.id,
+                        "schedules" to listOf(
+                                mapOf("startDateTime" to "2025-07-01T10:00:00", "endDateTime" to "2025-07-01T11:00:00")
+                        )
+                )
+
+                val response = req.post(
+                        "/calendars/$nonExistentCalendarId/schedules/share",
+                        body = body,
+                        token = token
+                )
+                res.assertFailure(response, ResponseStatus.CALENDAR_NOT_FOUND)
+            }
+        }
+
+        context("target 캘린더가 존재하지 않는 경우(toCalendar)") {
+            it("404 Not Found(CALENDAR_NOT_FOUND)를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                        "targetCalendarId" to 999_999L,
+                        "schedules" to listOf(
+                                mapOf("startDateTime" to "2025-07-01T10:00:00", "endDateTime" to "2025-07-01T11:00:00")
+                        )
+                )
+
+                val response = req.post(
+                        "/calendars/${fromCalendar.id}/schedules/share",
+                        body = body,
+                        token = token
+                )
+                res.assertFailure(response, ResponseStatus.CALENDAR_NOT_FOUND)
+            }
+        }
+
+        context("fromCalendar에 참여자가 아닌 경우") {
+            it("403 INVALID_CALENDAR_PARTICIPATION을 반환한다") {
+                val memberBelongTo = memberRepository.save(createMember(nickname = "not_participant_1"))
+                val toParticipant = createParticipant(
+                        member = memberBelongTo,
+                        calendar = toCalendar,
+                        role = Role.EDIT, // 요구사항: participant 이면서 edit 이상
+                        participationStatus = ParticipationStatus.ACCEPTED,
+                        nickname = "to-nickname2" // title로 복사되어야 함
+                )
+                toCalendar.addParticipant(toParticipant)
+                calendarRepository.save(toCalendar)
+
+                val token = jwtFixture.createValidToken(memberBelongTo.id)
+                val body = mapOf(
+                        "targetCalendarId" to toCalendar.id,
+                        "schedules" to listOf(
+                                mapOf("startDateTime" to "2025-07-01T10:00:00", "endDateTime" to "2025-07-01T11:00:00")
+                        )
+                )
+
+                val response = req.post(
+                        "/calendars/${fromCalendar.id}/schedules/share",
+                        body = body,
+                        token = token
+                )
+                res.assertFailure(response, ResponseStatus.PARTICIPANT_NOT_FOUND)
+            }
+        }
+
+        context("toCalendar에 참여자가 아닌 경우") {
+            it("403 INVALID_CALENDAR_PARTICIPATION을 반환한다") {
+                val memberBelongFrom = memberRepository.save(createMember(nickname = "not_participant_2"))
+                val fromParticipant = createParticipant(
+                        member = memberBelongFrom,
+                        calendar = fromCalendar,
+                        role = Role.VIEW, // 조회 권한이면 충분 (요구사항: from은 participant면 ok)
+                        participationStatus = ParticipationStatus.ACCEPTED
+                )
+                fromCalendar.addParticipant(fromParticipant)
+                calendarRepository.save(fromCalendar)
+
+                val token = jwtFixture.createValidToken(memberBelongFrom.id)
+                val body = mapOf(
+                        "targetCalendarId" to toCalendar.id,
+                        "schedules" to listOf(
+                                mapOf("startDateTime" to "2025-07-01T10:00:00", "endDateTime" to "2025-07-01T11:00:00")
+                        )
+                )
+
+                val response = req.post(
+                        "/calendars/${fromCalendar.id}/schedules/share",
+                        body = body,
+                        token = token
+                )
+                res.assertFailure(response, ResponseStatus.PARTICIPANT_NOT_FOUND)
+            }
+        }
+
+        context("잘못된 입력 - end < start") {
+            it("400 Bad Request(INVALID_SCHEDULE_RANGE)를 반환한다") {
+                val token = jwtFixture.createValidToken(member.id)
+                val body = mapOf(
+                        "targetCalendarId" to toCalendar.id,
+                        "schedules" to listOf(
+                                mapOf("startDateTime" to "2025-07-02T12:00:00", "endDateTime" to "2025-07-02T11:00:00")
+                        )
+                )
+                val response = req.post(
+                        "/calendars/${fromCalendar.id}/schedules/share",
+                        body = body,
+                        token = token
+                )
+
+                res.assertFailure(response, ResponseStatus.INVALID_SCHEDULE_RANGE)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/scheduo/fixture/CategoryFixture.kt
+++ b/src/test/kotlin/com/example/scheduo/fixture/CategoryFixture.kt
@@ -10,3 +10,11 @@ fun createCategory(): Category {
         Color.RED
     )
 }
+
+fun createCategory(name: String): Category {
+    return Category(
+            null,
+            name,
+            Color.RED
+    )
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
- #104 

## 🎁 작업 내용
- 일정 공유 시, 특정 attribute에 default 처리
  - 일정 title은 targetCalendar의 닉네임 
  - category는 default
  - location, memo, recurrence는 null 
  - allDay는 서버에서 계산해서

- startDateTime < endDateTime 미 충족 시, 에러 반환
- fromCalendar는 participant이면 OK
- toCalendar는 participant이면서 EDIT이상이면 OK

### 테스트
<img width="717" height="292" alt="image" src="https://github.com/user-attachments/assets/8413ffbe-1008-4f73-b0ed-58c9d2858b3b" />
