### PR TITLE
[Feat] 일정 검색 api 구현

### DIFF
--- a/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/controller/ScheduleController.java
@@ -97,4 +97,13 @@ public class ScheduleController {
 		return ApiResponse.onSuccess(res);
 	}
 
+	@Operation(summary = "일정 검색", description = "내가 속해있는 모든 캘린더의 일정에 대해서 keyword 기준으로 검색합니다.")
+	@GetMapping("/schedules/search")
+	public ApiResponse<ScheduleResponseDto.SearchList> searchSchedules(
+		@RequestMember Member member,
+		@RequestParam("keyword") String keyword
+	) {
+		ScheduleResponseDto.SearchList res = scheduleService.searchSchedules(member, keyword);
+		return ApiResponse.onSuccess(res);
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/dto/ScheduleResponseDto.java
@@ -1,8 +1,8 @@
 package com.example.scheduo.domain.schedule.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -194,6 +194,44 @@ public class ScheduleResponseDto {
 				schedule.getEndDate().toString(),
 				schedule.getStartTime().toString(),
 				schedule.getEndTime().toString()
+			);
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class SearchList {
+		private List<SearchContent> contents;
+
+		public static SearchList from(List<Schedule> schedules) {
+			List<SearchContent> searchContents = schedules.stream()
+				.map(SearchContent::from)
+				.collect(Collectors.toList());
+
+			return new SearchList(searchContents);
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class SearchContent {
+		private Long scheduleId;
+		private Long calendarId;
+		private String calendarName;
+		private String title;
+		private LocalDateTime startDateTime;
+		private LocalDateTime endDateTime;
+
+		public static SearchContent from(Schedule schedule) {
+			return new SearchContent(
+				schedule.getId(),
+				schedule.getCalendar().getId(),
+				schedule.getCalendar().getName(),
+				schedule.getTitle(),
+				schedule.getStartDate().atTime(schedule.getStartTime()),
+				schedule.getEndDate().atTime(schedule.getEndTime())
 			);
 		}
 	}

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/ScheduleJpqlRepository.java
@@ -22,4 +22,7 @@ public interface ScheduleJpqlRepository {
 
 	// 특정 일정 조회
 	Optional<Schedule> findScheduleByIdFetchJoin(Long scheduleId);
+
+	// 키워드 prefix 기반으로 내가 속해있는 모든 캘린더의 일정 검색 (내가 만든 일정이 아님)
+	List<Schedule> searchByMemberIdAndKeywordPrefix(Long memberId, String keyword);
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/repository/impl/ScheduleJpqlRepositoryImpl.java
@@ -99,4 +99,22 @@ public class ScheduleJpqlRepositoryImpl implements ScheduleJpqlRepository {
 			.findFirst();
 	}
 
+	@Override
+	public List<Schedule> searchByMemberIdAndKeywordPrefix(Long memberId, String keyword) {
+		// prefix 검색을 위해 keyword% 형태로 바인딩
+		String likeParam = keyword + "%";
+		String jpql = """
+			SELECT s FROM Schedule s
+			JOIN FETCH s.calendar c
+			JOIN c.participants p
+			WHERE p.member.id = :memberId
+				AND lower(s.title) LIKE lower(:kw)
+			ORDER BY s.startDate, s.startTime, s.id
+			""";
+
+		return entityManager.createQuery(jpql, Schedule.class)
+			.setParameter("memberId", memberId)
+			.setParameter("kw", likeParam)
+			.getResultList();
+	}
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -350,4 +350,12 @@ public class ScheduleServiceImpl implements ScheduleService {
 
 		return ScheduleResponseDto.SchedulesInRange.from(filteredSchedules);
 	}
+
+	@Override
+	public ScheduleResponseDto.SearchList searchSchedules(Member member, String keyword) {
+		// 키워드를 기반으로 내가 속해있는 캘린더의 모든 일정 검색
+		List<Schedule> myScheduleList = scheduleRepository.searchByMemberIdAndKeywordPrefix(member.getId(), keyword);
+		return ScheduleResponseDto.SearchList.from(myScheduleList);
+	}
+
 }

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -418,7 +418,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 
 	@Override
 	public ScheduleResponseDto.SearchList searchSchedules(Member member, String keyword) {
-		if (keyword == "") {
+		if (keyword.isBlank()) {
 			return new ScheduleResponseDto.SearchList(Collections.emptyList());
 		}
 

--- a/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/Impl/ScheduleServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.scheduo.domain.schedule.service.Impl;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -353,6 +354,10 @@ public class ScheduleServiceImpl implements ScheduleService {
 
 	@Override
 	public ScheduleResponseDto.SearchList searchSchedules(Member member, String keyword) {
+		if (keyword == "") {
+			return new ScheduleResponseDto.SearchList(Collections.emptyList());
+		}
+
 		// 키워드를 기반으로 내가 속해있는 캘린더의 모든 일정 검색
 		List<Schedule> myScheduleList = scheduleRepository.searchByMemberIdAndKeywordPrefix(member.getId(), keyword);
 		return ScheduleResponseDto.SearchList.from(myScheduleList);

--- a/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduo/domain/schedule/service/ScheduleService.java
@@ -17,4 +17,6 @@ public interface ScheduleService {
 		String date);
 
 	ScheduleResponseDto.SchedulesInRange getSchedulesInRange(Member member, Long calendarId, String startDate, String endDate);
+
+	ScheduleResponseDto.SearchList searchSchedules(Member member, String keyword);
 }

--- a/src/test/kotlin/com/example/scheduo/domain/schedule/controller/SearchScheduleTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/schedule/controller/SearchScheduleTest.kt
@@ -1,0 +1,335 @@
+package com.example.scheduo.domain.schedule.controller
+
+import com.example.scheduo.domain.calendar.entity.Calendar
+import com.example.scheduo.domain.calendar.entity.ParticipationStatus
+import com.example.scheduo.domain.calendar.entity.Role
+import com.example.scheduo.domain.calendar.repository.CalendarRepository
+import com.example.scheduo.domain.member.entity.Member
+import com.example.scheduo.domain.member.repository.MemberRepository
+import com.example.scheduo.domain.schedule.entity.Schedule
+import com.example.scheduo.domain.schedule.repository.CategoryRepository
+import com.example.scheduo.domain.schedule.repository.RecurrenceRepository
+import com.example.scheduo.domain.schedule.repository.ScheduleRepository
+import com.example.scheduo.fixture.*
+import com.example.scheduo.global.response.status.ResponseStatus
+import com.example.scheduo.util.Request
+import com.example.scheduo.util.Response
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SearchScheduleTest(
+        @Autowired val mockMvc: MockMvc,
+        @Autowired val objectMapper: ObjectMapper,
+        @Autowired val memberRepository: MemberRepository,
+        @Autowired val calendarRepository: CalendarRepository,
+        @Autowired val categoryRepository: CategoryRepository,
+        @Autowired val scheduleRepository: ScheduleRepository,
+        @Autowired val recurrenceRepository: RecurrenceRepository,
+        @Autowired val jwtFixture: JwtFixture,
+) : DescribeSpec({
+
+    lateinit var req: Request
+    lateinit var res: Response
+    lateinit var me: Member
+    lateinit var myCalA: Calendar
+    lateinit var myCalB: Calendar
+    lateinit var otherCal: Calendar
+
+    beforeSpec {
+        // 데이터 초기화
+        scheduleRepository.deleteAll()
+        recurrenceRepository.deleteAll()
+        categoryRepository.deleteAll()
+        calendarRepository.deleteAll()
+        memberRepository.deleteAll()
+
+        req = Request(mockMvc, objectMapper)
+        res = Response(objectMapper)
+
+        // 사용자 및 캘린더/참여 설정
+        me = memberRepository.save(createMember(nickname = "searcher"))
+        myCalA = createCalendar(name = "Work")
+        myCalB = createCalendar(name = "Weekend")
+        otherCal = createCalendar(name = "Other")
+
+        val pA = createParticipant(
+                member = me,
+                calendar = myCalA,
+                role = Role.EDIT,
+                participationStatus = ParticipationStatus.ACCEPTED
+        )
+        val pB = createParticipant(
+                member = me,
+                calendar = myCalB,
+                role = Role.EDIT,
+                participationStatus = ParticipationStatus.ACCEPTED
+        )
+        myCalA.addParticipant(pA)
+        myCalB.addParticipant(pB)
+
+        // 다른 사람 멤버/참여는 만들지 않아도 범위 테스트 가능
+        calendarRepository.saveAll(listOf(myCalA, myCalB, otherCal))
+    }
+
+    afterSpec {
+        scheduleRepository.deleteAll()
+        recurrenceRepository.deleteAll()
+        categoryRepository.deleteAll()
+        calendarRepository.deleteAll()
+        memberRepository.deleteAll()
+    }
+
+    fun saveSchedule(
+            title: String,
+            calendar: Calendar,
+            owner: Member = me,
+            start: String = "2025-08-10",
+            end: String = "2025-08-10"
+    ): Schedule {
+        val cat = categoryRepository.save(createCategory())
+        return scheduleRepository.save(
+                createSchedule(
+                        title = title,
+                        startDate = start,
+                        endDate = end,
+                        member = owner,
+                        calendar = calendar,
+                        category = cat
+                )
+        )
+    }
+
+    fun search(keyword: String, tokenMemberId: Long = me.id): String {
+        val token = jwtFixture.createValidToken(tokenMemberId)
+        val response = req.get("/schedules/search?keyword=$keyword", token = token)
+        res.assertSuccess(response) // 기본적으로 200 OK 성공을 기대
+        return response.contentAsString
+    }
+
+    describe("GET /schedules/search") {
+
+        context("keyword 경계 - 빈 문자열") {
+            it("빈 문자열이면 모든 내 캘린더의 모든 스케줄이 반환된다(빈 prefix는 전체 매칭)") {
+                // 준비
+                val s1 = saveSchedule("Meet", myCalA)
+                val s2 = saveSchedule("memo", myCalA)
+                val s3 = saveSchedule("Alpha", myCalB)
+                val s4 = saveSchedule("beta", myCalB)
+                // otherCal 스케줄(내가 속하지 않음)
+                val sX = saveSchedule("Meet outside", otherCal)
+
+                // 실행
+                val response = search(keyword = "")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                contents.shouldHaveSize(0)
+            }
+        }
+
+        context("keyword 경계 - 대소문자 무시") {
+            it("'m'로 검색하면 'Meet', 'memo'가 반환된다") {
+                scheduleRepository.deleteAll()
+                val s1 = saveSchedule("Meet", myCalA)
+                val s2 = saveSchedule("memo", myCalB)
+                val s3 = saveSchedule("Beta", myCalA)
+
+                val response = search(keyword = "m")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                val titles = contents.elements().asSequence()
+                        .map { it.get("title").asText() }
+                        .toList()
+
+                titles.shouldContainExactlyInAnyOrder(listOf("Meet", "memo"))
+            }
+        }
+
+        context("keyword 경계 - 공백 시작/끝") {
+            it("'  Me' 처럼 앞에 공백이 있으면 prefix 매칭 실패하여 0건을 반환한다") {
+                scheduleRepository.deleteAll()
+                saveSchedule("Meet", myCalA)
+                saveSchedule("Memo", myCalA)
+
+                val response = search(keyword = "  Me")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                contents.shouldHaveSize(0)
+            }
+
+            it("'Me  ' 처럼 뒤에 공백이 있으면 'Me  %'로 매칭되어 결과가 0건일 수 있다") {
+                scheduleRepository.deleteAll()
+                saveSchedule("Me", myCalA)
+                saveSchedule("Mezz", myCalA)
+
+                val response = search(keyword = "Me  ")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                contents.shouldHaveSize(0)
+            }
+        }
+
+        context("범위 경계 - 내가 속한 캘린더만 포함") {
+            it("다른 캘린더(otherCal)의 스케줄은 결과에서 제외된다") {
+                scheduleRepository.deleteAll()
+                val s1 = saveSchedule("Meet", myCalA)
+                val s2 = saveSchedule("Meet", myCalB)
+                val sX = saveSchedule("Meet", otherCal)
+
+                val response = search(keyword = "Me")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                val ids = contents.elements().asSequence()
+                        .map { it.get("scheduleId").asLong() }
+                        .toList()
+
+                ids.shouldContainExactlyInAnyOrder(listOf(s1.id, s2.id))
+            }
+        }
+
+        context("결과 경계 - 0건") {
+            it("매칭 0건이면 빈 리스트를 반환한다") {
+                scheduleRepository.deleteAll()
+                saveSchedule("Alpha", myCalA)
+
+                val response = search(keyword = "Z")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                contents.shouldHaveSize(0)
+            }
+        }
+
+        context("결과 경계 - 1건") {
+            it("매칭 1건이면 해당 스케줄만 반환한다") {
+                scheduleRepository.deleteAll()
+                val s = saveSchedule("Meeting", myCalA)
+
+                val response = search(keyword = "Meet")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                val titles = contents.elements().asSequence()
+                        .map { it.get("title").asText() }
+                        .toList()
+
+                titles.shouldContainExactlyInAnyOrder(listOf("Meeting"))
+            }
+        }
+
+        context("결과 경계 - n개") {
+            it("다건이면 startDate, startTime, id 순으로 정렬된다") {
+                scheduleRepository.deleteAll()
+                val a1 = saveSchedule("Meet-1", myCalA, start = "2025-08-10", end = "2025-08-10")
+                val a2 = saveSchedule("Meet-2", myCalA, start = "2025-08-10", end = "2025-08-10") // 같은 날, id 순 정렬 영향
+                val b1 = saveSchedule("Meet-3", myCalA, start = "2025-08-11", end = "2025-08-11")
+
+                val response = search(keyword = "Meet")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                val ids = contents.elements().asSequence()
+                        .map { it.get("scheduleId").asLong() }
+                        .toList()
+
+                ids shouldBe listOf(a1.id, a2.id, b1.id)
+            }
+        }
+
+        context("반복 일정과 단일 일정 혼재") {
+            it("반복/단일과 무관하게 title prefix 기준으로 동일하게 매칭된다") {
+                scheduleRepository.deleteAll()
+
+                val catA = categoryRepository.save(createCategory())
+                val catB = categoryRepository.save(createCategory())
+                val rec = recurrenceRepository.save(createRecurrence(frequency = "WEEKLY", recurrenceEndDate = "2025-12-31"))
+
+                val single = scheduleRepository.save(
+                        createSchedule(
+                                title = "Review",
+                                startDate = "2025-08-01",
+                                endDate = "2025-08-01",
+                                member = me,
+                                calendar = myCalA,
+                                category = catA
+                        )
+                )
+
+                val recurring = scheduleRepository.save(
+                        createSchedule(
+                                title = "Review weekly",
+                                startDate = "2025-08-01",
+                                endDate = "2025-08-01",
+                                member = me,
+                                calendar = myCalA,
+                                category = catB,
+                                recurrence = rec
+                        )
+                )
+
+                val response = search(keyword = "Re")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                val titles = contents.elements().asSequence()
+                        .map { it.get("title").asText() }
+                        .toList()
+
+                titles.shouldContainExactlyInAnyOrder(listOf("Review", "Review weekly"))
+            }
+        }
+
+        context("반복 일정 검색") {
+            it("반복 일정은 단일 일정과 동일하게 하나의 결과로 검색된다") {
+                scheduleRepository.deleteAll()
+
+                val cat = categoryRepository.save(createCategory())
+                val rec = recurrenceRepository.save(createRecurrence(frequency = "WEEKLY", recurrenceEndDate = "2025-12-31"))
+
+                val recurring = scheduleRepository.save(
+                        createSchedule(
+                                title = "Review weekly",
+                                startDate = "2025-08-01",
+                                endDate = "2025-08-01",
+                                member = me,
+                                calendar = myCalA,
+                                category = cat,
+                                recurrence = rec
+                        )
+                )
+
+                val response = search(keyword = "Re")
+                val json = objectMapper.readTree(response)
+                val contents = json["data"]["contents"]
+
+                contents.shouldHaveSize(1)
+            }
+        }
+
+        context("인증/권한 경계 - 미인증") {
+            it("미인증이면 401 Unauthorized를 반환한다") {
+                scheduleRepository.deleteAll()
+                saveSchedule("Meet", myCalA)
+
+                val response = req.get("/schedules/search?keyword=Me", token = null)
+
+                res.assertFailure(response, ResponseStatus.NOT_EXIST_TOKEN)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/scheduo/domain/schedule/controller/SearchScheduleTest.kt
+++ b/src/test/kotlin/com/example/scheduo/domain/schedule/controller/SearchScheduleTest.kt
@@ -120,7 +120,7 @@ class SearchScheduleTest(
     describe("GET /schedules/search") {
 
         context("keyword 경계 - 빈 문자열") {
-            it("빈 문자열이면 모든 내 캘린더의 모든 스케줄이 반환된다(빈 prefix는 전체 매칭)") {
+            it("빈 문자열이면 빈 리스트를 반환한다") {
                 // 준비
                 val s1 = saveSchedule("Meet", myCalA)
                 val s2 = saveSchedule("memo", myCalA)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #이슈번호
- #108 

## 🎁 작업 내용
- 유저가 생성한 일정이 아닌, 유저가 속한 캘린더의 모든 일정에 대해 조회
- 키워드 없을 시, 빈 리스트 반환
- 페이지네이션 기능 없음
  - 따라서 반복 일정의 결과는 하나만 나옴
- 대소문자 구분 x

### 테스트
<img width="699" height="306" alt="image" src="https://github.com/user-attachments/assets/5dc7c6c2-bb11-4213-9628-aebff6cd940c" />
